### PR TITLE
Switch to result objects and process pools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ author = "John Reese"
 author-email = "john@noswap.com"
 description-file = "README.md"
 home-page = "https://ufmt.omnilib.dev"
-requires = ["black>=20.8b0", "usort>=0.5.0"]
+requires = ["black>=20.8b0", "moreorless>=0.4.0", "usort>=0.5.0"]
 requires-python = ">=3.6"
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/ufmt/cli.py
+++ b/ufmt/cli.py
@@ -7,9 +7,10 @@ from pathlib import Path
 from typing import List
 
 import click
+from moreorless.click import echo_color_precomputed_diff
 
 from .__version__ import __version__
-from .core import ufmt_paths
+from .core import ufmt_paths, Result
 
 
 def init_logging(*, debug: bool = False) -> None:
@@ -19,6 +20,22 @@ def init_logging(*, debug: bool = False) -> None:
         format="%(message)s" if not debug else "%(levelname)s %(name)s %(message)s",
     )
     logging.getLogger("blib2to3").setLevel(logging.WARNING)
+
+
+def echo_results(results: List[Result], diff: bool = False) -> bool:
+    changed = False
+
+    for result in results:
+        if result.changed:
+            changed = True
+            if result.written:
+                click.echo(f"Formatted {result.path}")
+            else:
+                click.echo(f"Would format {result.path}")
+            if diff and result.diff:
+                echo_color_precomputed_diff(result.diff)
+
+    return changed
 
 
 @click.group()
@@ -34,7 +51,8 @@ def main(debug: bool):
 def check(ctx: click.Context, names: List[str]):
     """Check formatting of one or more paths"""
     paths = [Path(name) for name in names] if names else [Path(".")]
-    changed = ufmt_paths(paths, dry_run=True)
+    results = ufmt_paths(paths, dry_run=True)
+    changed = echo_results(results)
     if changed:
         ctx.exit(1)
 
@@ -45,7 +63,8 @@ def check(ctx: click.Context, names: List[str]):
 def diff(ctx: click.Context, names: List[str]):
     """Generate diffs for any files that need formatting"""
     paths = [Path(name) for name in names] if names else [Path(".")]
-    changed = ufmt_paths(paths, dry_run=True, diff=True)
+    results = ufmt_paths(paths, dry_run=True, diff=True)
+    changed = echo_results(results, diff=True)
     if changed:
         ctx.exit(1)
 
@@ -55,4 +74,5 @@ def diff(ctx: click.Context, names: List[str]):
 def format(names: List[str]):
     """Format one or more paths in place"""
     paths = [Path(name) for name in names] if names else [Path(".")]
-    ufmt_paths(paths)
+    results = ufmt_paths(paths)
+    echo_results(results)

--- a/ufmt/tests/cli.py
+++ b/ufmt/tests/cli.py
@@ -2,16 +2,19 @@
 # Licensed under the MIT license
 
 import os
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import patch, call
 
 from click.testing import CliRunner
 
-from ufmt.cli import main
+from ufmt.cli import main, echo_results
+from ufmt.core import Result
 
 
+@patch("ufmt.core.EXECUTOR", ThreadPoolExecutor)
 class CliTest(TestCase):
     def setUp(self):
         self.cwd = os.getcwd()
@@ -32,6 +35,47 @@ class CliTest(TestCase):
         os.chdir(self.cwd)
         self.td.cleanup()
 
+    @patch("ufmt.cli.echo_color_precomputed_diff")
+    @patch("ufmt.cli.click.echo")
+    def test_echo(self, echo_mock, mol_mock):
+        f1 = Path("foo/bar.py")
+        f2 = Path("fuzz/buzz.py")
+        f3 = Path("make/rake.py")
+        results = [
+            Result(f1, changed=False),
+            Result(f2, changed=True, written=False, diff="fakediff1"),
+            Result(f3, changed=True, written=True, diff="fakediff2"),
+        ]
+
+        with self.subTest("no diff"):
+            echo_results(results)
+            echo_mock.assert_has_calls(
+                [
+                    call(f"Would format {f2}"),
+                    call(f"Formatted {f3}"),
+                ]
+            )
+            mol_mock.assert_not_called()
+            echo_mock.reset_mock()
+            mol_mock.reset_mock()
+
+        with self.subTest("with diff"):
+            echo_results(results, diff=True)
+            echo_mock.assert_has_calls(
+                [
+                    call(f"Would format {f2}"),
+                    call(f"Formatted {f3}"),
+                ]
+            )
+            mol_mock.assert_has_calls(
+                [
+                    call("fakediff1"),
+                    call("fakediff2"),
+                ]
+            )
+            echo_mock.reset_mock()
+            mol_mock.reset_mock()
+
     @patch("ufmt.cli.ufmt_paths")
     def test_check(self, ufmt_mock):
         runner = CliRunner()
@@ -45,23 +89,29 @@ class CliTest(TestCase):
 
         with self.subTest("no paths given"):
             ufmt_mock.reset_mock()
-            ufmt_mock.return_value = False
+            ufmt_mock.return_value = []
             result = runner.invoke(main, ["check"])
             ufmt_mock.assert_called_with([Path(".")], dry_run=True)
             self.assertEqual(0, result.exit_code)
 
-        with self.subTest("given paths formatted"):
+        with self.subTest("already formatted"):
             ufmt_mock.reset_mock()
-            ufmt_mock.return_value = False
+            ufmt_mock.return_value = [
+                Result(Path("bar.py"), changed=False),
+                Result(Path("foo/frob.py"), changed=False),
+            ]
             result = runner.invoke(main, ["check", "bar.py", "foo/frob.py"])
             ufmt_mock.assert_called_with(
                 [Path("bar.py"), Path("foo/frob.py")], dry_run=True
             )
             self.assertEqual(0, result.exit_code)
 
-        with self.subTest("given paths unformatted"):
+        with self.subTest("needs formatting"):
             ufmt_mock.reset_mock()
-            ufmt_mock.return_value = True
+            ufmt_mock.return_value = [
+                Result(Path("bar.py"), changed=False),
+                Result(Path("foo/frob.py"), changed=True),
+            ]
             result = runner.invoke(main, ["check", "bar.py", "foo/frob.py"])
             ufmt_mock.assert_called_with(
                 [Path("bar.py"), Path("foo/frob.py")], dry_run=True
@@ -81,23 +131,29 @@ class CliTest(TestCase):
 
         with self.subTest("no paths given"):
             ufmt_mock.reset_mock()
-            ufmt_mock.return_value = False
+            ufmt_mock.return_value = []
             result = runner.invoke(main, ["diff"])
             ufmt_mock.assert_called_with([Path(".")], dry_run=True, diff=True)
             self.assertEqual(0, result.exit_code)
 
-        with self.subTest("given paths formatted"):
+        with self.subTest("already formatted"):
             ufmt_mock.reset_mock()
-            ufmt_mock.return_value = False
+            ufmt_mock.return_value = [
+                Result(Path("bar.py"), changed=False),
+                Result(Path("foo/frob.py"), changed=False),
+            ]
             result = runner.invoke(main, ["diff", "bar.py", "foo/frob.py"])
             ufmt_mock.assert_called_with(
                 [Path("bar.py"), Path("foo/frob.py")], dry_run=True, diff=True
             )
             self.assertEqual(0, result.exit_code)
 
-        with self.subTest("given paths unformatted"):
+        with self.subTest("needs formatting"):
             ufmt_mock.reset_mock()
-            ufmt_mock.return_value = True
+            ufmt_mock.return_value = [
+                Result(Path("bar.py"), changed=False),
+                Result(Path("foo/frob.py"), changed=True),
+            ]
             result = runner.invoke(main, ["diff", "bar.py", "foo/frob.py"])
             ufmt_mock.assert_called_with(
                 [Path("bar.py"), Path("foo/frob.py")], dry_run=True, diff=True
@@ -116,21 +172,27 @@ class CliTest(TestCase):
 
         with self.subTest("no paths given"):
             ufmt_mock.reset_mock()
-            ufmt_mock.return_value = False
+            ufmt_mock.return_value = []
             result = runner.invoke(main, ["format"])
             ufmt_mock.assert_called_with([Path(".")])
             self.assertEqual(0, result.exit_code)
 
-        with self.subTest("given paths formatted"):
+        with self.subTest("already formatted"):
             ufmt_mock.reset_mock()
-            ufmt_mock.return_value = False
+            ufmt_mock.return_value = [
+                Result(Path("bar.py"), changed=False),
+                Result(Path("foo/frob.py"), changed=False),
+            ]
             result = runner.invoke(main, ["format", "bar.py", "foo/frob.py"])
             ufmt_mock.assert_called_with([Path("bar.py"), Path("foo/frob.py")])
             self.assertEqual(0, result.exit_code)
 
-        with self.subTest("given paths unformatted"):
+        with self.subTest("needs formatting"):
             ufmt_mock.reset_mock()
-            ufmt_mock.return_value = True
+            ufmt_mock.return_value = [
+                Result(Path("bar.py"), changed=False),
+                Result(Path("foo/frob.py"), changed=True),
+            ]
             result = runner.invoke(main, ["format", "bar.py", "foo/frob.py"])
             ufmt_mock.assert_called_with([Path("bar.py"), Path("foo/frob.py")])
             self.assertEqual(0, result.exit_code)


### PR DESCRIPTION
Introduce new Result object as return value from ufmt_file, which
can be used to return file path, whether it changed, and what the
resulting diff was. This allows using ufmt_file from an executor
and aggregating the results in the parent process.

ufmt_paths now uses an executor when running ufmt_file on each path
to check. This allows concurrent formatting of multiple files, which
cuts the overall runtime on the botorch project from ~15s to ~4s on
an M1 Mac Mini. Running `black --diff` on the same directory runs in
~3.5s, while `usort check` takes ~14s, so this is about as fast as
we can get it without resorting to native extensions for everything.

Fixes #4