### PR TITLE
Switch to trailrunning.walk_and_run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ author = "John Reese"
 author-email = "john@noswap.com"
 description-file = "README.md"
 home-page = "https://ufmt.omnilib.dev"
-requires = ["black>=20.8b0", "moreorless>=0.4.0", "usort>=0.5.0"]
+requires = ["black>=20.8b0", "moreorless>=0.4.0", "trailrunner>=1.0", "usort>=0.5.0"]
 requires-python = ">=3.6"
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/ufmt/tests/cli.py
+++ b/ufmt/tests/cli.py
@@ -14,7 +14,7 @@ from ufmt.cli import main, echo_results
 from ufmt.core import Result
 
 
-@patch("ufmt.core.EXECUTOR", ThreadPoolExecutor)
+@patch("trailrunner.core.EXECUTOR", ThreadPoolExecutor)
 class CliTest(TestCase):
     def setUp(self):
         self.cwd = os.getcwd()

--- a/ufmt/tests/core.py
+++ b/ufmt/tests/core.py
@@ -55,7 +55,7 @@ def func(arg: str = "default") -> bool:
 '''
 
 
-@patch("ufmt.core.EXECUTOR", ThreadPoolExecutor)
+@patch("trailrunner.core.EXECUTOR", ThreadPoolExecutor)
 class CoreTest(TestCase):
     maxDiff = None
 


### PR DESCRIPTION
Switches to the new trailrunner library for walking paths (and obeying .gitignore), and running `ufmt_file` across a process pool.

This would obviate the need for PR #9 