### PR TITLE
auto-detect black config

### DIFF
--- a/ufmt/core.py
+++ b/ufmt/core.py
@@ -52,7 +52,7 @@ def ufmt_string(
     return content
 
 
-def _make_black_config(path: Path) -> Mode:
+def make_black_config(path: Path) -> Mode:
     config_file = find_pyproject_toml((str(path),))
     if not config_file:
         return Mode()
@@ -79,7 +79,7 @@ def _make_black_config(path: Path) -> Mode:
 
 def ufmt_file(path: Path, dry_run: bool = False, diff: bool = False) -> Result:
     usort_config = UsortConfig.find(path)
-    black_config = _make_black_config(path)
+    black_config = make_black_config(path)
 
     LOG.debug(f"Checking {path}")
 

--- a/ufmt/core.py
+++ b/ufmt/core.py
@@ -9,10 +9,17 @@ from multiprocessing import get_context
 from pathlib import Path
 from typing import List, Optional
 
-from black import decode_bytes, format_file_contents, Mode, NothingChanged
+from black import (
+    decode_bytes,
+    format_file_contents,
+    Mode,
+    NothingChanged,
+    parse_pyproject_toml,
+    find_pyproject_toml,
+)
 from moreorless.click import unified_diff
 from trailrunner import walk_and_run
-from usort.config import Config
+from usort.config import Config as UsortConfig
 from usort.sorting import usort_string
 
 LOG = logging.getLogger(__name__)
@@ -29,27 +36,57 @@ class Result:
     diff: Optional[str] = None
 
 
-def ufmt_string(path: Path, content: str, config: Config) -> str:
-    content = usort_string(content, config, path)
-    mode = Mode()  # TODO
+def ufmt_string(
+    path: Path,
+    content: str,
+    usort_config: UsortConfig,
+    black_config: Optional[Mode] = None,
+) -> str:
+    content = usort_string(content, usort_config, path)
 
     try:
-        content = format_file_contents(content, fast=False, mode=mode)
+        content = format_file_contents(content, fast=False, mode=black_config or Mode())
     except NothingChanged:
         pass
 
     return content
 
 
+def _make_black_config(path: Path) -> Mode:
+    config_file = find_pyproject_toml((str(path),))
+    if not config_file:
+        return Mode()
+
+    config = parse_pyproject_toml(config_file)
+
+    # manually patch options that do not have a 1-to-1 match in Mode arguments
+    config["target_versions"] = set(config.pop("target_version", []))
+    config["string_normalization"] = (
+        not config.pop("skip_string_normalization", False),
+    )
+    config["magic_trailing_comma"] = (
+        not config.pop("skip_magic_trailing_comma", False),
+    )
+
+    names = {
+        field.name
+        for field in Mode.__dataclass_fields__.values()  # type: ignore[attr-defined]
+    }
+    config = {name: value for name, value in config.items() if name in names}
+
+    return Mode(**config)
+
+
 def ufmt_file(path: Path, dry_run: bool = False, diff: bool = False) -> Result:
-    config = Config.find(path)
+    usort_config = UsortConfig.find(path)
+    black_config = _make_black_config(path)
 
     LOG.debug(f"Checking {path}")
 
     with open(path, "rb") as buf:
         src_contents, encoding, newline = decode_bytes(buf.read())
 
-    dst_contents = ufmt_string(path, src_contents, config)
+    dst_contents = ufmt_string(path, src_contents, usort_config, black_config)
 
     result = Result(path)
 

--- a/ufmt/core.py
+++ b/ufmt/core.py
@@ -61,12 +61,7 @@ def make_black_config(path: Path) -> Mode:
 
     # manually patch options that do not have a 1-to-1 match in Mode arguments
     config["target_versions"] = set(config.pop("target_version", []))
-    config["string_normalization"] = (
-        not config.pop("skip_string_normalization", False),
-    )
-    config["magic_trailing_comma"] = (
-        not config.pop("skip_magic_trailing_comma", False),
-    )
+    config["string_normalization"] = not config.pop("skip_string_normalization", False)
 
     names = {
         field.name


### PR DESCRIPTION
This addresses 

https://github.com/omnilib/ufmt/blob/29385731d3399d065968921b7502d321acf6faef/ufmt/core.py#L34

Instead of passing an empty configuration to `black`, with this PR `ufmt` now uses `black`'s internal logic to detect and parse a configuration file and use its values over the defaults. 

Cc @NicolasHug
