### PR TITLE
fix black config autodetection

### DIFF
--- a/ufmt/core.py
+++ b/ufmt/core.py
@@ -16,6 +16,7 @@ from black import (
     NothingChanged,
     parse_pyproject_toml,
     find_pyproject_toml,
+    TargetVersion,
 )
 from moreorless.click import unified_diff
 from trailrunner import walk_and_run
@@ -60,7 +61,9 @@ def make_black_config(path: Path) -> Mode:
     config = parse_pyproject_toml(config_file)
 
     # manually patch options that do not have a 1-to-1 match in Mode arguments
-    config["target_versions"] = set(config.pop("target_version", []))
+    config["target_versions"] = {
+        TargetVersion[val.upper()] for val in config.pop("target_version", [])
+    }
     config["string_normalization"] = not config.pop("skip_string_normalization", False)
 
     names = {

--- a/ufmt/tests/core.py
+++ b/ufmt/tests/core.py
@@ -5,8 +5,9 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
-from unittest.mock import patch, call, Mock, sentinel
+from unittest.mock import patch, call, Mock
 
+from black import TargetVersion
 from usort.config import Config
 
 import ufmt
@@ -55,6 +56,19 @@ def func(arg: str = "default") -> bool:
 '''
 
 
+def gen_pyproject_toml(**options):
+    def format(value):
+        if isinstance(value, bool):
+            return str(value).lower()
+        else:
+            return value
+
+    content = "[tool.black]\n\n"
+    for name, value in options.items():
+        content += f"{name} = {format(value)}\n"
+    return content
+
+
 @patch("trailrunner.core.EXECUTOR", ThreadPoolExecutor)
 class CoreTest(TestCase):
     maxDiff = None
@@ -70,40 +84,41 @@ class CoreTest(TestCase):
             result = ufmt.ufmt_string(Path("foo.py"), CORRECTLY_FORMATTED_CODE, config)
             self.assertEqual(CORRECTLY_FORMATTED_CODE, result)
 
-    def test_make_black_config(self):
-        pyproject_toml = sentinel.pyproject_toml
+    def test_black_config(self):
         config = dict(
-            target_version=["3.6", "3.7"],
+            target_version=["py36", "py37"],
             skip_string_normalization=True,
-            skip_magic_trailing_comma=True,
             line_length=87,
         )
 
-        with patch(
-            "ufmt.core.find_pyproject_toml",
-            return_value=pyproject_toml,
-        ):
-            with patch(
-                "ufmt.core.parse_pyproject_toml",
-                side_effect=lambda path_config: config.copy()
-                if path_config is pyproject_toml
-                else sentinel.DEFAULT,
-            ):
-                mode = ufmt.core.make_black_config(Path())
+        with TemporaryDirectory() as td:
+            td = Path(td)
 
-                with self.subTest("target_versions"):
-                    self.assertEqual(
-                        mode.target_versions, set(config["target_version"])
-                    )
+            pyproject_toml = td / "pyproject.toml"
+            pyproject_toml.write_text(gen_pyproject_toml(**config))
 
-                with self.subTest("string_normalization"):
-                    self.assertEqual(
-                        mode.string_normalization,
-                        not config["skip_string_normalization"],
-                    )
+            f = td / "foo.py"
+            f.write_text(POORLY_FORMATTED_CODE)
 
-                with self.subTest("line_length"):
-                    self.assertEqual(mode.line_length, config["line_length"])
+            result = ufmt.ufmt_file(f, dry_run=True)
+            self.assertTrue(result.changed)
+
+            mode = ufmt.core.make_black_config(td)
+
+            with self.subTest("target_versions"):
+                self.assertEqual(
+                    mode.target_versions,
+                    set(TargetVersion[val.upper()] for val in config["target_version"]),
+                )
+
+            with self.subTest("string_normalization"):
+                self.assertEqual(
+                    mode.string_normalization,
+                    not config["skip_string_normalization"],
+                )
+
+            with self.subTest("line_length"):
+                self.assertEqual(mode.line_length, config["line_length"])
 
     def test_ufmt_file(self):
         with TemporaryDirectory() as td:

--- a/ufmt/tests/core.py
+++ b/ufmt/tests/core.py
@@ -7,6 +7,7 @@ from tempfile import TemporaryDirectory
 from unittest import TestCase
 from unittest.mock import patch, call, Mock
 
+import trailrunner
 from black import TargetVersion
 from usort.config import Config
 
@@ -69,7 +70,7 @@ def func(arg: str = "default") -> bool:
 '''
 
 
-@patch("trailrunner.core.EXECUTOR", ThreadPoolExecutor)
+@patch.object(trailrunner.core.Trailrunner, "DEFAULT_EXECUTOR", ThreadPoolExecutor)
 class CoreTest(TestCase):
     maxDiff = None
 


### PR DESCRIPTION
Follow-up to #11. Since we mocked out the dependencies, the test suite didn't catch these errors. Without this PR `ufmt` is not runnable if it finds a `pyproject.toml`. In particular I botched the `target_version` which should be specified as `py36` instead of `3.6`. 

With this PR we now actually generate a simple `pyproject.toml` at runtime and check if it was parsed correctly. Plus, the test also performs a dry-run so we can be sure that `ufmt` still runs with an existing `black` config.