### PR TITLE
Add support for configurable "excludes"

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1,0 +1,43 @@
+User Guide
+==========
+
+Configuration
+-------------
+
+All configuration for µfmt is done via the :file:`pyproject.toml` file.  This is the
+same file that is used for configuring black and µsort.
+
+Specifying options requires adding them to the ``tool.ufmt`` namespace,
+following this example:
+
+.. code-block:: toml
+
+    [tool.ufmt]
+    excludes = [...]
+
+Options available are described as follows:
+
+.. attribute:: excludes
+    :type: List[str]
+
+    Optional list of supplemental patterns of file paths to exclude from formatting.
+    Each element must be a string following "gitignore" style matching rules. These
+    excludes will be combined with the contents of the project root's :file:`.gitignore`
+    file, and any file or directory path that matches any of these patterns will not be
+    formatted.
+
+    .. code-block:: toml
+        :caption: pyproject.toml
+
+        [tool.ufmt]
+        excludes = [
+            "fizz.py",
+            "foo/",
+        ]
+
+    This configuration would ignore the following paths when formatting a project:
+
+    * :file:`fizz.py`
+    * :file:`bar/fizz.py`
+    * :file:`foo/buzz.py`
+    * :file:`foo/bar/baz.py`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,6 +2,12 @@
 
 .. toctree::
     :hidden:
+    :maxdepth: 2
+
+    guide
+
+.. toctree::
+    :hidden:
     :maxdepth: 1
 
     changelog

--- a/makefile
+++ b/makefile
@@ -33,7 +33,7 @@ html: .venv README.md docs/*.rst docs/conf.py
 	source .venv/bin/activate && sphinx-build -b html docs html
 
 clean:
-	rm -rf build dist README MANIFEST *.egg-info .mypy_cache
+	rm -rf build dist html README MANIFEST *.egg-info .mypy_cache
 
 distclean: clean
 	rm -rf .venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ home-page = "https://ufmt.omnilib.dev"
 requires = [
     "black>=20.8b0",
     "moreorless>=0.4.0",
-    "trailrunner>=1.0",
+    "trailrunner>=1.1.0",
     "usort>=0.5.0",
 ]
 requires-python = ">=3.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ home-page = "https://ufmt.omnilib.dev"
 requires = [
     "black>=20.8b0",
     "moreorless>=0.4.0",
+    "tomlkit>=0.7.2",
     "trailrunner>=1.1.0",
     "usort>=0.5.0",
 ]

--- a/ufmt/config.py
+++ b/ufmt/config.py
@@ -1,0 +1,34 @@
+# Copyright 2021 John Reese
+# Licensed under the MIT license
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional, Dict, Any
+
+import tomlkit
+from trailrunner import project_root
+
+
+@dataclass
+class UfmtConfig:
+    project_root: Optional[Path] = None
+    pyproject_path: Optional[Path] = None
+    excludes: List[str] = field(default_factory=list)
+
+
+def ufmt_config(path: Optional[Path] = None) -> UfmtConfig:
+    path = path or Path.cwd()
+    root = project_root(path)
+    config_path = root / "pyproject.toml"
+    if config_path.is_file():
+        pyproject = tomlkit.loads(config_path.read_text())
+        config: Dict[str, Any] = {}
+
+        if "tool" in pyproject and "ufmt" in pyproject["tool"]:  # type: ignore
+            config.update(pyproject["tool"]["ufmt"])  # type: ignore
+
+        config["project_root"] = root
+        config["pyproject_path"] = config_path
+        return UfmtConfig(**config)
+
+    return UfmtConfig()

--- a/ufmt/core.py
+++ b/ufmt/core.py
@@ -2,10 +2,8 @@
 # Licensed under the MIT license
 
 import logging
-from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass
 from functools import partial
-from multiprocessing import get_context
 from pathlib import Path
 from typing import List, Optional
 
@@ -23,9 +21,6 @@ from usort.config import Config as UsortConfig
 from usort.sorting import usort_string
 
 LOG = logging.getLogger(__name__)
-
-CONTEXT = get_context("spawn")
-EXECUTOR = ProcessPoolExecutor
 
 
 @dataclass

--- a/ufmt/core.py
+++ b/ufmt/core.py
@@ -16,9 +16,11 @@ from black import (
     find_pyproject_toml,
 )
 from moreorless.click import unified_diff
-from trailrunner import walk_and_run
+from trailrunner import Trailrunner
 from usort.config import Config as UsortConfig
 from usort.sorting import usort_string
+
+from .config import ufmt_config
 
 LOG = logging.getLogger(__name__)
 
@@ -98,7 +100,13 @@ def ufmt_file(path: Path, dry_run: bool = False, diff: bool = False) -> Result:
 def ufmt_paths(
     paths: List[Path], dry_run: bool = False, diff: bool = False
 ) -> List[Result]:
+    all_paths: List[Path] = []
+    runner = Trailrunner()
+    for path in paths:
+        config = ufmt_config(path)
+        all_paths.extend(runner.walk(path, excludes=config.excludes))
+
     fn = partial(ufmt_file, dry_run=dry_run, diff=diff)
-    results = list(walk_and_run(paths, fn).values())
+    results = list(runner.run(all_paths, fn).values())
 
     return results

--- a/ufmt/tests/__init__.py
+++ b/ufmt/tests/__init__.py
@@ -2,4 +2,5 @@
 # Licensed under the MIT license
 
 from .cli import CliTest
+from .config import ConfigTest
 from .core import CoreTest

--- a/ufmt/tests/cli.py
+++ b/ufmt/tests/cli.py
@@ -8,13 +8,14 @@ from tempfile import TemporaryDirectory
 from unittest import TestCase
 from unittest.mock import patch, call
 
+import trailrunner
 from click.testing import CliRunner
 
 from ufmt.cli import main, echo_results
 from ufmt.core import Result
 
 
-@patch("trailrunner.core.EXECUTOR", ThreadPoolExecutor)
+@patch.object(trailrunner.core.Trailrunner, "DEFAULT_EXECUTOR", ThreadPoolExecutor)
 class CliTest(TestCase):
     def setUp(self):
         self.cwd = os.getcwd()

--- a/ufmt/tests/config.py
+++ b/ufmt/tests/config.py
@@ -1,0 +1,82 @@
+# Copyright 2021 John Reese
+# Licensed under the MIT license
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from textwrap import dedent
+from unittest import TestCase
+
+from trailrunner.tests.core import cd
+
+from ufmt.config import UfmtConfig, ufmt_config
+
+
+class ConfigTest(TestCase):
+    maxDiff = None
+
+    def test_ufmt_config(self):
+        fake_config = dedent(
+            """
+            [tool.ufmt]
+            excludes = [
+                "a",
+                "b",
+            ]
+        """
+        )
+
+        with TemporaryDirectory() as td:
+            td = Path(td).resolve()
+            foo = td / "foo"
+            foo.mkdir()
+            bar = foo / "bar.py"
+            bar.write_text("print('hello world')\n")
+
+            with self.subTest("absolute path, no pyproject.toml"):
+                config = ufmt_config(bar)
+                self.assertEqual(UfmtConfig(), config)
+
+            with self.subTest("local path, no pyproject.toml"):
+                with cd(foo):
+                    config = ufmt_config()
+                    self.assertEqual(UfmtConfig(), config)
+
+            pyproj = td / "pyproject.toml"
+            pyproj.write_text("")
+
+            with self.subTest("absolute path, empty pyproject.toml"):
+                config = ufmt_config(bar)
+                self.assertEqual(
+                    UfmtConfig(project_root=td, pyproject_path=pyproj, excludes=[]),
+                    config,
+                )
+
+            with self.subTest("local path, empty pyproject.toml"):
+                with cd(td):
+                    config = ufmt_config()
+                    self.assertEqual(
+                        UfmtConfig(project_root=td, pyproject_path=pyproj, excludes=[]),
+                        config,
+                    )
+
+            pyproj = td / "pyproject.toml"
+            pyproj.write_text(fake_config)
+
+            with self.subTest("absolute path, with pyproject.toml"):
+                config = ufmt_config(bar)
+                self.assertEqual(
+                    UfmtConfig(
+                        project_root=td, pyproject_path=pyproj, excludes=["a", "b"]
+                    ),
+                    config,
+                )
+
+            with self.subTest("local path, with pyproject.toml"):
+                with cd(td):
+                    config = ufmt_config()
+                    self.assertEqual(
+                        UfmtConfig(
+                            project_root=td, pyproject_path=pyproj, excludes=["a", "b"]
+                        ),
+                        config,
+                    )

--- a/ufmt/tests/core.py
+++ b/ufmt/tests/core.py
@@ -7,6 +7,7 @@ from tempfile import TemporaryDirectory
 from unittest import TestCase
 from unittest.mock import patch, call, Mock, sentinel
 
+import trailrunner
 from usort.config import Config
 
 import ufmt
@@ -55,7 +56,7 @@ def func(arg: str = "default") -> bool:
 '''
 
 
-@patch("trailrunner.core.EXECUTOR", ThreadPoolExecutor)
+@patch.object(trailrunner.core.Trailrunner, "DEFAULT_EXECUTOR", ThreadPoolExecutor)
 class CoreTest(TestCase):
     maxDiff = None
 

--- a/ufmt/tests/core.py
+++ b/ufmt/tests/core.py
@@ -12,6 +12,14 @@ from usort.config import Config
 
 import ufmt
 
+FAKE_CONFIG = """
+[tool.ufmt]
+excludes = [
+    "foo/frob/",
+    "__init__.py",
+]
+"""
+
 POORLY_FORMATTED_CODE = """\
 import click
 from re import compile
@@ -187,3 +195,33 @@ class CoreTest(TestCase):
                     )
                     self.assertTrue(all(r.changed for r in results))
                     file_wrapper.reset_mock()
+
+    def test_ufmt_paths_config(self):
+        with TemporaryDirectory() as td:
+            td = Path(td).resolve()
+            md = td / "foo"
+            md.mkdir()
+            f1 = md / "__init__.py"
+            f2 = md / "foo.py"
+            sd = md / "frob/"
+            sd.mkdir()
+            f3 = sd / "main.py"
+
+            for f in f1, f2, f3:
+                f.write_text(POORLY_FORMATTED_CODE)
+
+            pyproj = td / "pyproject.toml"
+            pyproj.write_text(FAKE_CONFIG)
+
+            file_wrapper = Mock(name="ufmt_file", wraps=ufmt.ufmt_file)
+            with patch("ufmt.core.ufmt_file", file_wrapper):
+                ufmt.ufmt_paths([td])
+                file_wrapper.assert_has_calls(
+                    [
+                        call(f2, dry_run=False, diff=False),
+                    ],
+                    any_order=True,
+                )
+                self.assertEqual(f1.read_text(), POORLY_FORMATTED_CODE)
+                self.assertEqual(f2.read_text(), CORRECTLY_FORMATTED_CODE)
+                self.assertEqual(f3.read_text(), POORLY_FORMATTED_CODE)


### PR DESCRIPTION
Adds support for configuring a set of "excludes" for µfmt in `pyproject.toml`. This uses "gitignore" style matching, and acts as a supplement to the existing behavior for excluding files in a `.gitignore` in the project's root directory:

```
[tool.ufmt]
excludes = [
    "examples/",
    "__init__.py",
]
```

This would prevent µfmt from applying any formatting to the following paths:

* `examples/foo.py`
* `foo/__init__.py`
* `foo/bar/__init__.py`

Fixes #12 