### PR TITLE
add pre-commit hook for ufmt

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: ufmt
+  name: Format source files with µfmt
+  description: Safe, atomic formatting with black and µsort
+  language: python
+  types:
+    - python
+  entry: ufmt format
+  require_serial: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,8 +1,8 @@
 - id: ufmt
-  name: Format source files with µfmt
+  name: Format files with µfmt
   description: Safe, atomic formatting with black and µsort
   language: python
-  types:
+  types_or:
     - python
   entry: ufmt format
   require_serial: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,5 +4,6 @@
   language: python
   types_or:
     - python
+    - pyi
   entry: ufmt format
   require_serial: true

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ $ ufmt diff <path> [<path> ...]
 `pre-commit` hook
 -----------------
 
-µfmt provides a [`pre-commit`](https://pre-commit.com) hook. To format your diff before 
+µfmt provides a [pre-commit](https://pre-commit.com) hook. To format your diff before 
 every commit, add the following to your `.pre-commit-config.yaml` file:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ $ ufmt diff <path> [<path> ...]
 ```
 
 
-`pre-commit` hook
+[pre-commit] hook
 -----------------
 
-µfmt provides a [pre-commit](https://pre-commit.com) hook. To format your diff before 
+µfmt provides a [pre-commit] hook. To format your diff before 
 every commit, add the following to your `.pre-commit-config.yaml` file:
 
 ```yaml
@@ -101,3 +101,4 @@ my code is from me and not from my employer. See the `LICENSE` file for details.
 
 [black]: https://black.readthedocs.io
 [µsort]: https://usort.readthedocs.io
+[pre-commit]: https://pre-commit.com

--- a/README.md
+++ b/README.md
@@ -65,6 +65,31 @@ $ ufmt diff <path> [<path> ...]
 ```
 
 
+`pre-commit` hook
+-----------------
+
+µfmt provides a [`pre-commit`](https://pre-commit.com) hook. To format your diff before 
+every commit, add the following to your `.pre-commit-config.yaml` file:
+
+```yaml
+  - repo: https://github.com/omnilib/ufmt
+    rev: 1.3.0
+    hooks:
+      - id: ufmt
+```
+
+You can change the `rev` to any version `>= 1.3.0`. To pin `black` and `usort`, use the 
+`additional_dependencies` option:
+
+```yaml
+    hooks: 
+      - id: ufmt 
+        additional_dependencies: 
+          - black == 20.8b0 
+          - usort == 0.6.3
+```
+
+
 License
 -------
 


### PR DESCRIPTION
As the name implies, [`pre-commit`](https://pre-commit.com) is a framework for running programs before a commit is performed. Especially for code formatters like `usort` they are really handy, because you actually want to run them before every commit. After the installation you don't need to worry about forgetting to format your code ever again and CI being the next instance to tell you that something is up.

Fortunately, the only thing that needs to added to enable `ufmt` as a `pre-commit` hook is a minimal configuration file.

 ToDo:

- [x] add documentation about the hook to the README
- [ ] ~add a test workflow to make  sure the hook can be installed and executed correctly~ (I no longer think this is needed, since we will rarely change the hook itself).