### PR TITLE
Correctly set `rev` in pre-commit README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ every commit, add the following to your `.pre-commit-config.yaml` file:
 
 ```yaml
   - repo: https://github.com/omnilib/ufmt
-    rev: 1.3.0
+    rev: v1.3.0
     hooks:
       - id: ufmt
 ```


### PR DESCRIPTION
`rev` is incorrectly set in pre-commit README example, as it has to follow the [tag names](https://github.com/omnilib/ufmt/tags).