### PR TITLE
Tell black when formatting type stubs

### DIFF
--- a/ufmt/core.py
+++ b/ufmt/core.py
@@ -41,9 +41,13 @@ def ufmt_string(
     black_config: Optional[Mode] = None,
 ) -> str:
     content = usort_string(content, usort_config, path)
+    mode = black_config or Mode()
+
+    if path.suffix == ".pyi":
+        mode.is_pyi = True
 
     try:
-        content = format_file_contents(content, fast=False, mode=black_config or Mode())
+        content = format_file_contents(content, fast=False, mode=mode)
     except NothingChanged:
         pass
 

--- a/ufmt/tests/core.py
+++ b/ufmt/tests/core.py
@@ -65,6 +65,33 @@ def func(arg: str = "default") -> bool:
     return arg == "default"
 '''
 
+POORLY_FORMATTED_STUB = """\
+import click
+import os
+
+def foo(a: int, b: str) -> bool:
+    ...
+
+class Bar:
+    def hello(
+        self,
+    ) -> None:
+        ...
+"""
+
+CORRECTLY_FORMATTED_STUB = """\
+import os
+
+import click
+
+def foo(a: int, b: str) -> bool: ...
+
+class Bar:
+    def hello(
+        self,
+    ) -> None: ...
+"""
+
 
 @patch.object(trailrunner.core.Trailrunner, "DEFAULT_EXECUTOR", ThreadPoolExecutor)
 class CoreTest(TestCase):
@@ -80,6 +107,10 @@ class CoreTest(TestCase):
         with self.subTest("unchanged"):
             result = ufmt.ufmt_string(Path("foo.py"), CORRECTLY_FORMATTED_CODE, config)
             self.assertEqual(CORRECTLY_FORMATTED_CODE, result)
+
+        with self.subTest("type stub"):
+            result = ufmt.ufmt_string(Path("foo.pyi"), POORLY_FORMATTED_STUB, config)
+            self.assertEqual(CORRECTLY_FORMATTED_STUB, result)
 
     def test_black_config(self):
         black_config = dict(


### PR DESCRIPTION
ufmt just tells black to format an arbitrary string, so black doesn't
otherwise know if we're formatting a type stub. This adds a check to
`ufmt_string()` that checks the file suffix/extension for `.pyi` and
sets the appropriate flag on black's config object before formatting.

Fixes #41