### PR TITLE
Basic error handling when formatting bytes and files

### DIFF
--- a/ufmt/core.py
+++ b/ufmt/core.py
@@ -45,6 +45,10 @@ def ufmt_bytes(
     represents a type stub (has a ``.pyi`` suffix), the black config object will be
     updated to set ``is_pyi = True``.
 
+    This function will not catch any errors during formatting, except for "everything is
+    fine" messages, like :exc:`black.NothingChanged`. All other errors must be handled
+    by the code calling this function; see :func:`ufmt_file` for example error handling.
+
     Optionally takes a post processor matching the :class:`PostProcessor` protocol.
     If given, the post processor will be called with the updated byte string content
     after it has been run through µsort and black. The return value of the post
@@ -139,6 +143,11 @@ def ufmt_file(
     changes to disk. Passing ``diff = True`` will generate a unified diff of changes
     on the :class:`Result` object.
 
+    Any errors that occur during formatting will be caught, and those exceptions will
+    be attached to the :attr:`Result.error` property of the result object. It is the
+    responsibility of code calling this function to check for errors in results and
+    handle or surface them appropriately.
+
     Optionally takes ``black_config_factory`` or ``usort_config_factory`` to override
     the default configuration detection for each respective tool. Factory functions
     must take a :class:`pathlib.Path` object and return a valid :class:`BlackConfig`
@@ -210,6 +219,10 @@ def ufmt_paths(
     performance and CPU utilization.
 
     Returns a list of :class:`Result` objects for each file formatted.
+    Any errors that occur during formatting will be caught, and those exceptions will
+    be attached to the :attr:`Result.error` property of the result object. It is the
+    responsibility of code calling this function to check for errors in results and
+    handle or surface them appropriately.
 
     See :func:`ufmt_file` for details on parameters, config factories,
     and post processors. All parameters are passed through to :func:`ufmt_file`.

--- a/ufmt/tests/cli.py
+++ b/ufmt/tests/cli.py
@@ -10,6 +10,7 @@ from unittest.mock import call, patch
 
 import trailrunner
 from click.testing import CliRunner
+from libcst import ParserSyntaxError
 
 from ufmt.cli import echo_results, main
 from ufmt.core import Result
@@ -119,6 +120,29 @@ class CliTest(TestCase):
             )
             self.assertEqual(1, result.exit_code)
 
+        with self.subTest("syntax error"):
+            ufmt_mock.reset_mock()
+            ufmt_mock.return_value = [
+                Result(Path("bar.py"), changed=False),
+                Result(
+                    Path("foo/frob.py"),
+                    error=ParserSyntaxError(
+                        "bad",
+                        lines=("", "", "", "foo bar fizzbuzz hello world"),
+                        raw_line=4,
+                        raw_column=15,
+                    ),
+                ),
+            ]
+            result = runner.invoke(main, ["check", "bar.py", "foo/frob.py"])
+            ufmt_mock.assert_called_with(
+                [Path("bar.py"), Path("foo/frob.py")], dry_run=True
+            )
+            self.assertRegex(
+                result.stdout, r"Error formatting foo/frob\.py: Syntax Error @ 4:16"
+            )
+            self.assertEqual(1, result.exit_code)
+
     @patch("ufmt.cli.ufmt_paths")
     def test_diff(self, ufmt_mock):
         runner = CliRunner()
@@ -161,6 +185,29 @@ class CliTest(TestCase):
             )
             self.assertEqual(1, result.exit_code)
 
+        with self.subTest("syntax error"):
+            ufmt_mock.reset_mock()
+            ufmt_mock.return_value = [
+                Result(Path("bar.py"), changed=False),
+                Result(
+                    Path("foo/frob.py"),
+                    error=ParserSyntaxError(
+                        "bad",
+                        lines=("", "", "", "foo bar fizzbuzz hello world"),
+                        raw_line=4,
+                        raw_column=15,
+                    ),
+                ),
+            ]
+            result = runner.invoke(main, ["diff", "bar.py", "foo/frob.py"])
+            ufmt_mock.assert_called_with(
+                [Path("bar.py"), Path("foo/frob.py")], dry_run=True, diff=True
+            )
+            self.assertRegex(
+                result.stdout, r"Error formatting foo/frob\.py: Syntax Error @ 4:16"
+            )
+            self.assertEqual(1, result.exit_code)
+
     @patch("ufmt.cli.ufmt_paths")
     def test_format(self, ufmt_mock):
         runner = CliRunner()
@@ -197,3 +244,24 @@ class CliTest(TestCase):
             result = runner.invoke(main, ["format", "bar.py", "foo/frob.py"])
             ufmt_mock.assert_called_with([Path("bar.py"), Path("foo/frob.py")])
             self.assertEqual(0, result.exit_code)
+
+        with self.subTest("syntax error"):
+            ufmt_mock.reset_mock()
+            ufmt_mock.return_value = [
+                Result(Path("bar.py"), changed=False),
+                Result(
+                    Path("foo/frob.py"),
+                    error=ParserSyntaxError(
+                        "bad",
+                        lines=("", "", "", "foo bar fizzbuzz hello world"),
+                        raw_line=4,
+                        raw_column=15,
+                    ),
+                ),
+            ]
+            result = runner.invoke(main, ["format", "bar.py", "foo/frob.py"])
+            ufmt_mock.assert_called_with([Path("bar.py"), Path("foo/frob.py")])
+            self.assertRegex(
+                result.stdout, r"Error formatting foo/frob\.py: Syntax Error @ 4:16"
+            )
+            self.assertEqual(1, result.exit_code)

--- a/ufmt/tests/cli.py
+++ b/ufmt/tests/cli.py
@@ -139,7 +139,7 @@ class CliTest(TestCase):
                 [Path("bar.py"), Path("foo/frob.py")], dry_run=True
             )
             self.assertRegex(
-                result.stdout, r"Error formatting foo/frob\.py: Syntax Error @ 4:16"
+                result.stdout, r"Error formatting .*frob\.py: Syntax Error @ 4:16"
             )
             self.assertEqual(1, result.exit_code)
 
@@ -204,7 +204,7 @@ class CliTest(TestCase):
                 [Path("bar.py"), Path("foo/frob.py")], dry_run=True, diff=True
             )
             self.assertRegex(
-                result.stdout, r"Error formatting foo/frob\.py: Syntax Error @ 4:16"
+                result.stdout, r"Error formatting .*frob\.py: Syntax Error @ 4:16"
             )
             self.assertEqual(1, result.exit_code)
 
@@ -262,6 +262,6 @@ class CliTest(TestCase):
             result = runner.invoke(main, ["format", "bar.py", "foo/frob.py"])
             ufmt_mock.assert_called_with([Path("bar.py"), Path("foo/frob.py")])
             self.assertRegex(
-                result.stdout, r"Error formatting foo/frob\.py: Syntax Error @ 4:16"
+                result.stdout, r"Error formatting .*frob\.py: Syntax Error @ 4:16"
             )
             self.assertEqual(1, result.exit_code)

--- a/ufmt/types.py
+++ b/ufmt/types.py
@@ -41,3 +41,4 @@ class Result:
     changed: bool = False
     written: bool = False
     diff: Optional[str] = None
+    error: Optional[Exception] = None


### PR DESCRIPTION
Adds the `.error` property to the result object, and does simple exception handling in `ufmt_bytes` and `ufmt_file` to catch and record errors during formatting. Adds tests to simulate both invalid syntax and file-not-found errors.

Fixes #55 