### PR TITLE
Switch ufmt_paths to a generator that yields results as completed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires = [
     "black>=20.8b0",
     "moreorless>=0.4.0",
     "tomlkit>=0.7.2",
-    "trailrunner>=1.2",
+    "trailrunner>=1.2.1",
     "typing_extensions>=4.0",
     "usort>=1.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires = [
     "black>=20.8b0",
     "moreorless>=0.4.0",
     "tomlkit>=0.7.2",
-    "trailrunner>=1.1.1",
+    "trailrunner>=1.2",
     "typing_extensions>=4.0",
     "usort>=1.0",
 ]

--- a/ufmt/cli.py
+++ b/ufmt/cli.py
@@ -4,7 +4,7 @@
 import logging
 import sys
 from pathlib import Path
-from typing import List, Tuple
+from typing import Iterable, List, Tuple
 
 import click
 from moreorless.click import echo_color_precomputed_diff
@@ -22,15 +22,14 @@ def init_logging(*, debug: bool = False) -> None:
     logging.getLogger("blib2to3").setLevel(logging.WARNING)
 
 
-def echo_results(results: List[Result], diff: bool = False) -> Tuple[bool, bool]:
-    if not results:
-        click.secho("No files found", fg="yellow", err=True)
-        return False, True
-
+def echo_results(results: Iterable[Result], diff: bool = False) -> Tuple[bool, bool]:
+    empty = True
     error = False
     changed = False
 
     for result in results:
+        empty = False
+
         if result.error is not None:
             msg = str(result.error)
             lines = msg.splitlines()
@@ -46,6 +45,10 @@ def echo_results(results: List[Result], diff: bool = False) -> Tuple[bool, bool]
                 click.echo(f"Would format {result.path}", err=True)
             if diff and result.diff:
                 echo_color_precomputed_diff(result.diff)
+
+    if empty:
+        click.secho("No files found", fg="yellow", err=True)
+        error = True
 
     return changed, error
 

--- a/ufmt/tests/core.py
+++ b/ufmt/tests/core.py
@@ -330,24 +330,26 @@ class CoreTest(TestCase):
             file_wrapper = Mock(name="ufmt_file", wraps=ufmt.ufmt_file)
             with patch("ufmt.core.ufmt_file", file_wrapper):
                 with self.subTest("no paths"):
-                    results = ufmt.ufmt_paths([], dry_run=True)
+                    results = list(ufmt.ufmt_paths([], dry_run=True))
                     self.assertEqual([], results)
                     file_wrapper.assert_not_called()
 
                 with self.subTest("non-existent paths"):
-                    results = ufmt.ufmt_paths(
-                        [(td / "fake.py"), (td / "another.py")], dry_run=True
+                    results = list(
+                        ufmt.ufmt_paths(
+                            [(td / "fake.py"), (td / "another.py")], dry_run=True
+                        )
                     )
                     self.assertEqual([], results)
 
                 with self.subTest("mixed paths with stdin"):
                     with patch("ufmt.core.LOG") as log_mock:
-                        results = ufmt.ufmt_paths([f1, STDIN, f3], dry_run=True)
+                        results = list(ufmt.ufmt_paths([f1, STDIN, f3], dry_run=True))
                         self.assertEqual(2, len(results))
                         log_mock.warning.assert_called_once()
 
                 with self.subTest("files"):
-                    results = ufmt.ufmt_paths([f1, f3], dry_run=True)
+                    results = list(ufmt.ufmt_paths([f1, f3], dry_run=True))
                     self.assertEqual(2, len(results))
                     file_wrapper.assert_has_calls(
                         [
@@ -378,7 +380,7 @@ class CoreTest(TestCase):
                     file_wrapper.reset_mock()
 
                 with self.subTest("files with diff"):
-                    results = ufmt.ufmt_paths([f1, f3], dry_run=True, diff=True)
+                    results = list(ufmt.ufmt_paths([f1, f3], dry_run=True, diff=True))
                     self.assertEqual(2, len(results))
                     file_wrapper.assert_has_calls(
                         [
@@ -409,7 +411,7 @@ class CoreTest(TestCase):
                     file_wrapper.reset_mock()
 
                 with self.subTest("subdir"):
-                    results = ufmt.ufmt_paths([sd])
+                    results = list(ufmt.ufmt_paths([sd]))
                     file_wrapper.assert_has_calls(
                         [
                             call(
@@ -443,7 +445,7 @@ class CoreTest(TestCase):
         stdin_mock.return_value = Result(path=STDIN, changed=True)
 
         with self.subTest("no name"):
-            ufmt.ufmt_paths([STDIN], dry_run=True)
+            list(ufmt.ufmt_paths([STDIN], dry_run=True))
             stdin_mock.assert_called_with(
                 Path("<stdin>"),
                 dry_run=True,
@@ -456,7 +458,7 @@ class CoreTest(TestCase):
             )
 
         with self.subTest("path name"):
-            ufmt.ufmt_paths([STDIN, Path("hello.py")], dry_run=True)
+            list(ufmt.ufmt_paths([STDIN, Path("hello.py")], dry_run=True))
             stdin_mock.assert_called_with(
                 Path("hello.py"),
                 dry_run=True,
@@ -470,7 +472,11 @@ class CoreTest(TestCase):
 
         with self.subTest("extra args"):
             with self.assertRaisesRegex(ValueError, "too many stdin paths"):
-                ufmt.ufmt_paths([STDIN, Path("hello.py"), Path("foo.py")], dry_run=True)
+                list(
+                    ufmt.ufmt_paths(
+                        [STDIN, Path("hello.py"), Path("foo.py")], dry_run=True
+                    )
+                )
 
     def test_ufmt_paths_config(self):
         with TemporaryDirectory() as td:
@@ -491,7 +497,7 @@ class CoreTest(TestCase):
 
             file_wrapper = Mock(name="ufmt_file", wraps=ufmt.ufmt_file)
             with patch("ufmt.core.ufmt_file", file_wrapper):
-                ufmt.ufmt_paths([td])
+                list(ufmt.ufmt_paths([td]))
                 file_wrapper.assert_has_calls(
                     [
                         call(


### PR DESCRIPTION
Allows the consumer of `ufmt_paths` to begin processing results as they come in, rather than waiting for all files to be formatted and results to be gathered first.

Fixes #74