### PR TITLE
Support skipping files based on pre/post processor

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -33,6 +33,8 @@ Simple API
 .. autoclass:: ufmt.Processor
     :special-members: __call__
 
+.. autoclass:: ufmt.SkipFormatting
+
 
 Low-level API
 -------------

--- a/ufmt/__init__.py
+++ b/ufmt/__init__.py
@@ -13,6 +13,7 @@ from .types import (
     Newline,
     Processor,
     Result,
+    SkipFormatting,
     UsortConfig,
     UsortConfigFactory,
 )
@@ -25,6 +26,7 @@ __all__ = [
     "Newline",
     "Processor",
     "Result",
+    "SkipFormatting",
     "ufmt_bytes",
     "ufmt_file",
     "ufmt_paths",

--- a/ufmt/cli.py
+++ b/ufmt/cli.py
@@ -37,7 +37,11 @@ def echo_results(results: Iterable[Result], diff: bool = False) -> Tuple[bool, b
             click.secho(f"Error formatting {result.path}: {msg}", fg="yellow", err=True)
             error = True
 
-        if result.changed:
+        elif result.skipped:
+            reason = f": {result.skipped}" if isinstance(result.skipped, str) else ""
+            click.echo(f"Skipped {result.path}{reason}")
+
+        elif result.changed:
             changed = True
             if result.written:
                 click.echo(f"Formatted {result.path}", err=True)

--- a/ufmt/core.py
+++ b/ufmt/core.py
@@ -23,6 +23,7 @@ from .types import (
     FileContent,
     Processor,
     Result,
+    SkipFormatting,
     STDIN,
     UsortConfig,
     UsortConfigFactory,
@@ -194,6 +195,11 @@ def ufmt_file(
             pre_processor=pre_processor,
             post_processor=post_processor,
         )
+    except SkipFormatting as e:
+        dst_contents = src_contents
+        result.skipped = str(e) or True
+        return result
+
     except Exception as e:
         result.error = e
         return result

--- a/ufmt/core.py
+++ b/ufmt/core.py
@@ -175,6 +175,11 @@ def ufmt_file(
     If given, the post processor will be called with the updated byte string content
     after it has been run through µsort and black. The return value of the post
     processor will replace the final return value of :func:`ufmt_bytes`.
+
+    Raising :exc:`ufmt.SkipFormatting` from a pre- or post-processor will result in
+    "skipping" the file currently being formatted. The final contents will be unchanged,
+    and the :attr:`Result.skipped` attribute will be set with the string message from
+    the skip exception, or ``True`` if no message is given.
     """
     path = path.resolve()
     black_config = (black_config_factory or make_black_config)(path)

--- a/ufmt/tests/cli.py
+++ b/ufmt/tests/cli.py
@@ -140,6 +140,16 @@ class CliTest(TestCase):
             )
             self.assertEqual(1, result.exit_code)
 
+        with self.subTest("skipped file"):
+            ufmt_mock.reset_mock()
+            ufmt_mock.return_value = [
+                Result(Path("foo.py"), skipped="special"),
+            ]
+            result = runner.invoke(main, ["check", "foo.py"])
+            ufmt_mock.assert_called_with([Path("foo.py")], dry_run=True)
+            self.assertRegex(result.stdout, r"Skipped .*foo\.py: special")
+            self.assertEqual(0, result.exit_code)
+
     @patch("ufmt.cli.ufmt_paths")
     def test_diff(self, ufmt_mock):
         runner = CliRunner()
@@ -199,6 +209,16 @@ class CliTest(TestCase):
             )
             self.assertEqual(1, result.exit_code)
 
+        with self.subTest("skipped file"):
+            ufmt_mock.reset_mock()
+            ufmt_mock.return_value = [
+                Result(Path("foo.py"), skipped="special"),
+            ]
+            result = runner.invoke(main, ["diff", "foo.py"])
+            ufmt_mock.assert_called_with([Path("foo.py")], dry_run=True, diff=True)
+            self.assertRegex(result.stdout, r"Skipped .*foo\.py: special")
+            self.assertEqual(0, result.exit_code)
+
     @patch("ufmt.cli.ufmt_paths")
     def test_format(self, ufmt_mock):
         runner = CliRunner()
@@ -251,6 +271,16 @@ class CliTest(TestCase):
                 result.stdout, r"Error formatting .*frob\.py: Syntax Error @ 4:16"
             )
             self.assertEqual(1, result.exit_code)
+
+        with self.subTest("skipped file"):
+            ufmt_mock.reset_mock()
+            ufmt_mock.return_value = [
+                Result(Path("foo.py"), skipped="special"),
+            ]
+            result = runner.invoke(main, ["format", "foo.py"])
+            ufmt_mock.assert_called_with([Path("foo.py")])
+            self.assertRegex(result.stdout, r"Skipped .*foo\.py: special")
+            self.assertEqual(0, result.exit_code)
 
     @skipIf(platform.system() == "Windows", "stderr not supported on Windows")
     def test_stdin(self) -> None:

--- a/ufmt/types.py
+++ b/ufmt/types.py
@@ -3,7 +3,7 @@
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Callable, Optional, Union
 
 from black import Mode as BlackConfig
 from typing_extensions import Protocol
@@ -33,6 +33,10 @@ class Processor(Protocol):
         ...
 
 
+class SkipFormatting(Exception):
+    """Raise this exception in a pre/post processor to skip formatting a file."""
+
+
 @dataclass
 class Result:
     """
@@ -42,6 +46,7 @@ class Result:
     path: Path
     changed: bool = False
     written: bool = False
+    skipped: Union[bool, str] = False
     diff: Optional[str] = None
     error: Optional[Exception] = None
     before: bytes = b""  # only set if return_content=True


### PR DESCRIPTION
- Adds the `SkipFormatting` exception class, and catches this exception in `ufmt_file`.
- Sets `Result.skipped` with the skip message or `True`.
- Echoes `Skipped <file>: <message>` to stderr, but leaves exit code as 0.
- Documents skip behavior in `ufmt_file`.