### PR TITLE
Preserve given path when formatting stdin

### DIFF
--- a/ufmt/tests/cli.py
+++ b/ufmt/tests/cli.py
@@ -322,7 +322,7 @@ class CliTest(TestCase):
                 ["diff", "-", "hello.py"],
                 input=POORLY_FORMATTED_CODE,
             )
-            self.assertRegex(result.stdout, r"---.*\n\+\+\+")
+            self.assertRegex(result.stdout, r"--- hello.py\n\+\+\+ hello.py")
             self.assertEqual("Would format hello.py\n", result.stderr)
             self.assertEqual(1, result.exit_code)
 

--- a/ufmt/tests/core.py
+++ b/ufmt/tests/core.py
@@ -339,6 +339,22 @@ class CoreTest(TestCase):
             stdout.seek(0)
             self.assertEqual(b"", stdout.read())
 
+        with self.subTest("diff with path"):
+            stdin_mock.buffer = stdin = io.BytesIO()
+            stdout_mock.buffer = stdout = io.BytesIO()
+
+            stdin.write(POORLY_FORMATTED_CODE.encode())
+            stdin.seek(0)
+
+            path = Path("hello/world.py")
+            result = ufmt_stdin(path, dry_run=True, diff=True)
+            self.assertIsNotNone(result.diff)
+            self.assertRegex(
+                result.diff, r"--- hello.world\.py\n\+\+\+ hello.world\.py"
+            )
+            stdout.seek(0)
+            self.assertEqual(b"", stdout.read())
+
         with self.subTest("format"):
             stdin_mock.buffer = stdin = io.BytesIO()
             stdout_mock.buffer = stdout = io.BytesIO()


### PR DESCRIPTION
This shortcircuits part of the workflow when formatting stdin,
by materializing black/usort configs earlier, and modifying the
generated diff output to replace temporary paths with the original
supplied paths.

Fixes #77