### PR TITLE
Fix #94: Make sure fake stdin paths are resolvable

### DIFF
--- a/ufmt/core.py
+++ b/ufmt/core.py
@@ -353,7 +353,7 @@ def ufmt_paths(
         elif len(paths) == 2:
             _, path = paths
         else:
-            path = Path("<stdin>")
+            path = Path("stdin")
         yield ufmt_stdin(
             path,
             dry_run=dry_run,

--- a/ufmt/tests/cli.py
+++ b/ufmt/tests/cli.py
@@ -303,7 +303,7 @@ class CliTest(TestCase):
                 input=POORLY_FORMATTED_CODE,
             )
             self.assertEqual("", result.stdout)
-            self.assertEqual("Would format <stdin>\n", result.stderr)
+            self.assertEqual("Would format stdin\n", result.stderr)
             self.assertEqual(1, result.exit_code)
 
         with self.subTest("diff clean"):


### PR DESCRIPTION
The previous fake path used by ufmt_paths when formatting stdin
was not resolvable on Windows, breaking any pre- or post-processor
that needed to resolve paths during formatting. This changes the
default fake path to remove the unallowed characters, and adds a
simple test case with a pre-processor. This test fails with old
behavior, and passes with the new fake path name.