### PR TITLE
Print a report after formatting

### DIFF
--- a/ufmt/cli.py
+++ b/ufmt/cli.py
@@ -23,10 +23,14 @@ def init_logging(*, debug: Optional[bool] = None) -> None:
     logging.getLogger("blib2to3").setLevel(logging.WARNING)
 
 
-def echo_results(results: Iterable[Result], diff: bool = False) -> Tuple[bool, bool]:
+def echo_results(
+    results: Iterable[Result], diff: bool = False, quiet: bool = False
+) -> Tuple[int, int]:
     empty = True
-    error = False
-    changed = False
+    error = 0
+    changed = 0
+    written = 0
+    clean = 0
 
     for result in results:
         empty = False
@@ -36,26 +40,52 @@ def echo_results(results: Iterable[Result], diff: bool = False) -> Tuple[bool, b
             lines = msg.splitlines()
             msg = lines[0]
             click.secho(f"Error formatting {result.path}: {msg}", fg="yellow", err=True)
-            error = True
+            error += 1
 
         elif result.skipped:
             reason = f": {result.skipped}" if isinstance(result.skipped, str) else ""
-            click.echo(f"Skipped {result.path}{reason}", err=True)
+            if not quiet:
+                click.secho(f"Skipped {result.path}{reason}", err=True)
 
         elif result.changed:
-            changed = True
             if result.written:
-                click.echo(f"Formatted {result.path}", err=True)
+                written += 1
+                if not quiet:
+                    click.secho(f"Formatted {result.path}", err=True)
             else:
-                click.echo(f"Would format {result.path}", err=True)
+                changed += 1
+                click.secho(f"Would format {result.path}", err=True)
             if diff and result.diff:
                 echo_color_precomputed_diff(result.diff)
 
+        else:
+            clean += 1
+
     if empty:
         click.secho("No files found", fg="yellow", err=True)
-        error = True
+        error += 1
 
-    return changed, error
+    if not quiet:
+
+        def f(v: int) -> str:
+            return "file" if v == 1 else "files"
+
+        reports = []
+        if error:
+            reports += [click.style(f"{error} errors", fg="yellow", bold=True)]
+        if changed:
+            reports += [
+                click.style(f"{changed} {f(changed)} would be formatted", bold=True)
+            ]
+        if written:
+            reports += [click.style(f"{written} {f(written)} formatted")]
+        if clean:
+            reports += [click.style(f"{clean} {f(clean)} already formatted")]
+
+        message = ", ".join(reports)
+        click.secho(f"✨ {message} ✨", err=True)
+
+    return (changed + written), error
 
 
 @click.group()
@@ -83,9 +113,10 @@ def main(ctx: click.Context, debug: Optional[bool]):
 )
 def check(ctx: click.Context, names: List[str]):
     """Check formatting of one or more paths"""
+    options: Options = ctx.obj
     paths = [Path(name) for name in names] if names else [Path(".")]
     results = ufmt_paths(paths, dry_run=True)
-    changed, error = echo_results(results)
+    changed, error = echo_results(results, quiet=options.quiet)
     if changed or error:
         ctx.exit(1)
 
@@ -97,9 +128,10 @@ def check(ctx: click.Context, names: List[str]):
 )
 def diff(ctx: click.Context, names: List[str]):
     """Generate diffs for any files that need formatting"""
+    options: Options = ctx.obj
     paths = [Path(name) for name in names] if names else [Path(".")]
     results = ufmt_paths(paths, dry_run=True, diff=True)
-    changed, error = echo_results(results, diff=True)
+    changed, error = echo_results(results, diff=True, quiet=options.quiet)
     if changed or error:
         ctx.exit(1)
 
@@ -111,8 +143,9 @@ def diff(ctx: click.Context, names: List[str]):
 )
 def format(ctx: click.Context, names: List[str]):
     """Format one or more paths in place"""
+    options: Options = ctx.obj
     paths = [Path(name) for name in names] if names else [Path(".")]
     results = ufmt_paths(paths)
-    _, error = echo_results(results)
+    _, error = echo_results(results, quiet=options.quiet)
     if error:
         ctx.exit(1)

--- a/ufmt/cli.py
+++ b/ufmt/cli.py
@@ -39,7 +39,7 @@ def echo_results(results: Iterable[Result], diff: bool = False) -> Tuple[bool, b
 
         elif result.skipped:
             reason = f": {result.skipped}" if isinstance(result.skipped, str) else ""
-            click.echo(f"Skipped {result.path}{reason}")
+            click.echo(f"Skipped {result.path}{reason}", err=True)
 
         elif result.changed:
             changed = True

--- a/ufmt/tests/cli.py
+++ b/ufmt/tests/cli.py
@@ -25,17 +25,8 @@ class CliTest(TestCase):
         self.runner = CliRunner(mix_stderr=False)
         self.cwd = os.getcwd()
         self.td = TemporaryDirectory()
-        td = Path(self.td.name)
-        f1 = td / "bar.py"
-        sd = td / "foo"
-        sd.mkdir()
-        f2 = sd / "baz.py"
-        f3 = sd / "frob.py"
-
-        for f in f1, f2, f3:
-            f.write_text("\n")
-
-        os.chdir(td)
+        self.tdp = Path(self.td.name)
+        os.chdir(self.tdp)
 
     def tearDown(self):
         os.chdir(self.cwd)

--- a/ufmt/tests/cli.py
+++ b/ufmt/tests/cli.py
@@ -146,7 +146,7 @@ class CliTest(TestCase):
             ]
             result = self.runner.invoke(main, ["check", "foo.py"])
             ufmt_mock.assert_called_with([Path("foo.py")], dry_run=True)
-            self.assertRegex(result.stdout, r"Skipped .*foo\.py: special")
+            self.assertRegex(result.stderr, r"Skipped .*foo\.py: special")
             self.assertEqual(0, result.exit_code)
 
     @patch("ufmt.cli.ufmt_paths")
@@ -213,7 +213,7 @@ class CliTest(TestCase):
             ]
             result = self.runner.invoke(main, ["diff", "foo.py"])
             ufmt_mock.assert_called_with([Path("foo.py")], dry_run=True, diff=True)
-            self.assertRegex(result.stdout, r"Skipped .*foo\.py: special")
+            self.assertRegex(result.stderr, r"Skipped .*foo\.py: special")
             self.assertEqual(0, result.exit_code)
 
     @patch("ufmt.cli.ufmt_paths")
@@ -274,7 +274,7 @@ class CliTest(TestCase):
             ]
             result = self.runner.invoke(main, ["format", "foo.py"])
             ufmt_mock.assert_called_with([Path("foo.py")])
-            self.assertRegex(result.stdout, r"Skipped .*foo\.py: special")
+            self.assertRegex(result.stderr, r"Skipped .*foo\.py: special")
             self.assertEqual(0, result.exit_code)
 
     @skipIf(platform.system() == "Windows", "stderr not supported on Windows")

--- a/ufmt/types.py
+++ b/ufmt/types.py
@@ -19,6 +19,12 @@ BlackConfigFactory = Callable[[Path], BlackConfig]
 UsortConfigFactory = Callable[[Path], UsortConfig]
 
 
+@dataclass
+class Options:
+    debug: bool = False
+    quiet: bool = False
+
+
 class Processor(Protocol):
     def __call__(
         self,


### PR DESCRIPTION
After formatting, prints a single line with counts for:
- errors triggered
- files that would be formatted
- files that were formatted
- files that were already correct

Looks something like:

```
Would format /Users/jreese/workspace/ufmt/ufmt/tests/cli.py
✨ 1 file would be formatted, 13 files already formatted ✨
```

Closes #98 