### PR TITLE
Github Actions support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,27 @@ $ ufmt diff <path> [<path> ...]
 ```
 
 
+Github Actions
+--------------
+
+µfmt provides a Github Action that can be added to an existing Github Actions workflow,
+or as a separate workflow or job, to enforce proper formatting in pull requests:
+
+```yaml
+name: Formatting
+on:
+  pull_request:
+jobs:
+  ufmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: omnilib/ufmt@x1
+        with:
+          path: <PATH TO CHECK>
+          python-version: "3.x"
+```
+
+
 [pre-commit] hook
 -----------------
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,10 @@ $ ufmt diff <path> [<path> ...]
 ```
 
 
-GitHub Actions
---------------
+Integrations
+------------
+
+### GitHub Actions
 
 µfmt provides a GitHub Action that can be added to an existing workflow,
 or as a separate workflow or job, to enforce proper formatting in pull requests:
@@ -82,11 +84,9 @@ jobs:
 
 See the [user guide](https://ufmt.omnilib.dev/en/latest/guide.html#github-actions) for details.
 
+### pre-commit hook
 
-[pre-commit] hook
------------------
-
-µfmt provides a [pre-commit] hook. To format your diff before 
+µfmt provides a [pre-commit][] hook. To format your diff before
 every commit, add the following to your `.pre-commit-config.yaml` file:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -63,25 +63,24 @@ $ ufmt diff <path> [<path> ...]
 ```
 
 
-Github Actions
+GitHub Actions
 --------------
 
-µfmt provides a Github Action that can be added to an existing Github Actions workflow,
+µfmt provides a GitHub Action that can be added to an existing workflow,
 or as a separate workflow or job, to enforce proper formatting in pull requests:
 
 ```yaml
-name: Formatting
-on:
-  pull_request:
 jobs:
   ufmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: omnilib/ufmt@x1
+      - uses: omnilib/ufmt@action-v1
         with:
           path: <PATH TO CHECK>
           python-version: "3.x"
 ```
+
+See the [user guide](https://ufmt.omnilib.dev/en/latest/guide.html#github-actions) for details.
 
 
 [pre-commit] hook
@@ -92,21 +91,15 @@ every commit, add the following to your `.pre-commit-config.yaml` file:
 
 ```yaml
   - repo: https://github.com/omnilib/ufmt
-    rev: v1.3.2
+    rev: v1.3.3
     hooks:
       - id: ufmt
-```
-
-You can change the `rev` to any version `>= 1.3.0`. To pin `black` and `usort`, use the 
-`additional_dependencies` option:
-
-```yaml
-    hooks: 
-      - id: ufmt 
         additional_dependencies: 
-          - black == 22.3.0
-          - usort == 1.0.2
+          - black == 22.6.0
+          - usort == 1.0.3
 ```
+
+See the [user guide](https://ufmt.omnilib.dev/en/latest/guide.html#pre-commit) for details.
 
 
 License

--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,6 @@
 name: "µfmt"
 description: "Validate formatting and import sorting"
 inputs:
-  diff:
-    description: "Show diff output"
-    required: false
-    default: true
   path:
     description: "Paths to check"
     required: true
@@ -40,10 +36,5 @@ runs:
       run: python -m pip install "usort==${{ inputs.usort_version }}"
       shell: bash
     - name: Check formatting
-      if: ${{ inputs.diff == true }}
       run: ufmt diff ${{ inputs.path }}
-      shell: bash
-    - name: Check formatting (no diff)
-      if: ${{ inputs.diff == false }}
-      run: ufmt check ${{ inputs.path }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -19,14 +19,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install µfmt
-      if: ${{ inputs.version == 'latest' }}
-      run: python -m pip install ufmt
-      shell: bash
-    - name: Install µfmt ${{ inputs.version }}
-      if: ${{ inputs.version != 'latest' }}
-      run: python -m pip install "ufmt==${{ inputs.version }}"
-      shell: bash
     - name: Install black ${{ inputs.black_version }}
       if: ${{ inputs.black_version }}
       run: python -m pip install "black==${{ inputs.black_version }}"
@@ -34,6 +26,14 @@ runs:
     - name: Install µsort ${{ inputs.usort_version }}
       if: ${{ inputs.usort_version }}
       run: python -m pip install "usort==${{ inputs.usort_version }}"
+      shell: bash
+    - name: Install µfmt
+      if: ${{ inputs.version == 'latest' }}
+      run: python -m pip install ufmt
+      shell: bash
+    - name: Install µfmt ${{ inputs.version }}
+      if: ${{ inputs.version != 'latest' }}
+      run: python -m pip install "ufmt==${{ inputs.version }}"
       shell: bash
     - name: Check formatting
       run: ufmt diff ${{ inputs.path }}

--- a/action.yml
+++ b/action.yml
@@ -14,8 +14,11 @@ runs:
     - name: Install µfmt
       if: ${{ inputs.version == 'latest' }}
       run: python -m pip install ufmt
+      shell: bash
     - name: Install µfmt ${{ inputs.version }}
       if: ${{ inputs.version != 'latest' }}
       run: python -m pip install "ufmt==${{ inputs.version }}"
+      shell: bash
     - name: Check formatting
       run: ufmt check ${{ inputs.path }}
+      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,21 @@
+name: "µfmt"
+description: "Validate formatting and import sorting"
+inputs:
+  path:
+    description: "Paths to check"
+    required: true
+  version:
+    description: "µfmt version to install"
+    required: false
+    default: "latest"
+runs:
+  using: "composite"
+  steps:
+    - name: Install µfmt
+      if: ${{ inputs.version == 'latest' }}
+      run: python -m pip install ufmt
+    - name: Install µfmt ${{ inputs.version }}
+      if: ${{ inputs.version != 'latest' }}
+      run: python -m pip install "ufmt==${{ inputs.version }}"
+    - name: Check formatting
+      run: ufmt check ${{ inputs.path }}

--- a/action.yml
+++ b/action.yml
@@ -36,5 +36,5 @@ runs:
       run: python -m pip install "ufmt==${{ inputs.version }}"
       shell: bash
     - name: Check formatting
-      run: ufmt diff ${{ inputs.path }}
+      run: python -m ufmt diff ${{ inputs.path }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,10 @@
 name: "µfmt"
 description: "Validate formatting and import sorting"
 inputs:
+  diff:
+    description: "Show diff output"
+    required: false
+    default: true
   path:
     description: "Paths to check"
     required: true
@@ -8,6 +12,14 @@ inputs:
     description: "µfmt version to install"
     required: false
     default: "latest"
+  black_version:
+    description: "black version to install"
+    required: false
+    default: ""
+  usort_version:
+    description: "µsort version to install"
+    required: false
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -19,6 +31,19 @@ runs:
       if: ${{ inputs.version != 'latest' }}
       run: python -m pip install "ufmt==${{ inputs.version }}"
       shell: bash
+    - name: Install black ${{ inputs.black_version }}
+      if: ${{ inputs.black_version }}
+      run: python -m pip install "black==${{ inputs.black_version }}"
+      shell: bash
+    - name: Install µsort ${{ inputs.usort_version }}
+      if: ${{ inputs.usort_version }}
+      run: python -m pip install "black==${{ inputs.usort_version }}"
+      shell: bash
     - name: Check formatting
+      if: ${{ inputs.diff }}
+      run: ufmt diff ${{ inputs.path }}
+      shell: bash
+    - name: Check formatting (no diff)
+      if: ${{ ! inputs.diff }}
       run: ufmt check ${{ inputs.path }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -8,24 +8,35 @@ inputs:
     description: "µfmt version to install"
     required: false
     default: "latest"
-  black_version:
+  black-version:
     description: "black version to install"
     required: false
     default: ""
-  usort_version:
+  python-version:
+    description: "Install Python with the given version"
+    required: false
+    default: ""
+  usort-version:
     description: "µsort version to install"
     required: false
     default: ""
 runs:
   using: "composite"
   steps:
-    - name: Install black ${{ inputs.black_version }}
-      if: ${{ inputs.black_version }}
-      run: python -m pip install "black==${{ inputs.black_version }}"
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup Python
+      if: ${{ inputs.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ inputs.python-version }}
+    - name: Install black ${{ inputs.black-version }}
+      if: ${{ inputs.black-version }}
+      run: python -m pip install "black==${{ inputs.black-version }}"
       shell: bash
-    - name: Install µsort ${{ inputs.usort_version }}
-      if: ${{ inputs.usort_version }}
-      run: python -m pip install "usort==${{ inputs.usort_version }}"
+    - name: Install µsort ${{ inputs.usort-version }}
+      if: ${{ inputs.usort-version }}
+      run: python -m pip install "usort==${{ inputs.usort-version }}"
       shell: bash
     - name: Install µfmt
       if: ${{ inputs.version == 'latest' }}

--- a/action.yml
+++ b/action.yml
@@ -40,10 +40,10 @@ runs:
       run: python -m pip install "usort==${{ inputs.usort_version }}"
       shell: bash
     - name: Check formatting
-      if: ${{ inputs.diff }}
+      if: ${{ inputs.diff == true }}
       run: ufmt diff ${{ inputs.path }}
       shell: bash
     - name: Check formatting (no diff)
-      if: ${{ ! inputs.diff }}
+      if: ${{ inputs.diff == false }}
       run: ufmt check ${{ inputs.path }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ runs:
       shell: bash
     - name: Install µsort ${{ inputs.usort_version }}
       if: ${{ inputs.usort_version }}
-      run: python -m pip install "black==${{ inputs.usort_version }}"
+      run: python -m pip install "usort==${{ inputs.usort_version }}"
       shell: bash
     - name: Check formatting
       if: ${{ inputs.diff }}

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -41,3 +41,115 @@ Options available are described as follows:
     * :file:`bar/fizz.py`
     * :file:`foo/buzz.py`
     * :file:`foo/bar/baz.py`
+
+
+Integrations
+------------
+
+µfmt supports integrations with the following tools and services:
+
+- `GitHub Actions`_
+- `pre-commit`_
+
+
+GitHub Actions
+~~~~~~~~~~~~~~
+
+µfmt can be run as part of a project's existing Actions workflow, adding the following
+snippet to the ``steps`` section of a job:
+
+.. code-block:: yaml
+
+    steps:
+      - uses: omnilib/ufmt@action-v1
+        with:
+          path: <PATH TO CHECK>
+
+This can also be added as a standalone workflow. If a ``setup-python`` step is not
+already used, the :attr:`python-version` input must be specified:
+
+.. code-block:: yaml
+    :caption: .github/workflows/ufmt.yml
+
+    name: "µfmt"
+    on:
+      push:
+        branches:
+          - main
+      pull_request:
+    jobs:
+      check:
+        runs-on: ubuntu-latest
+        steps:
+          - name: Check formatting
+            uses: omnilib/ufmt@action-v1
+            with:
+              path: <PATH TO CHECK>
+              python-version: "3.x"
+
+The following inputs are supported to change the way the Action is performed, and
+must be specified as part of the ``with`` section of the job step:
+
+.. attribute:: path (required)
+
+    One or more paths (relative to the repository root) that should be checked.
+
+.. attribute:: version
+
+    The version of µfmt to install and use when checking formatting.
+
+    Defaults to installing the latest version, or whatever version is already installed
+    by previous steps in the workflow.
+
+.. attribute:: black-version
+
+    The version of black to install and use when checking formatting.
+
+    Defaults to installing the latest version, or whatever version is already installed
+    by previous steps in the workflow.
+
+.. attribute:: python-version
+
+    When specified, the Github ``actions/setup-python`` action will be triggered, with
+    the given version string as the desired version of Python to use. Using ``"3.x"``
+    is recommended, to run µfmt using the latest stable release of Python.
+
+    See the `setup-python advanced usage`__ for supported values.
+
+    .. __: https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#using-the-python-version-input
+
+.. attribute:: usort-version
+
+    The version of µsort to install and use when checking formatting.
+
+    Defaults to installing the latest version, or whatever version is already installed
+    by previous steps in the workflow.
+
+
+pre-commit
+~~~~~~~~~~
+
+µfmt can format your project automatically before every commit as part of a project's
+`pre-commit <https://pre-commit.com>`_ hook. Add the following to the
+``.pre-commit-config.yaml`` file:
+
+.. code-block:: yaml
+
+    - repo: https://github.com/omnilib/ufmt
+      rev: v1.3.3
+      hooks:
+        - id: ufmt
+
+.. attribute:: additional_dependencies
+
+    Preferred versions of black and µsort should be provided for consistent results.
+    By default, µfmt will format using the latest versions of black and µsort.
+
+    .. code-block:: yaml
+
+        - repo: https://github.com/omnilib/ufmt
+          hooks:
+            - id: ufmt
+              additional_dependencies:
+                - black == 22.6.0
+                - usort == 1.0.3


### PR DESCRIPTION
Adds a new Github Action spec that checks a project for valid formatting via ufmt.

The action performs the following:
- checkout the project
- setup python (if python-version specified)
- install black/usort (if versions specified)
- install ufmt (latest or specific version)
- runs `python -m ufmt check` against given `path`

Also adds a new "integrations" section to the user guide, and also documents the pre-commit support there. The appropriate sections of the user guide are now linked to from the readme.

Documented examples depend on adding a new `action-v1` tag to the repo (named so that it doesn't conflict with actual version tags in the changelog).