### PR TITLE
Validate pyproject.toml configuration more stringently

### DIFF
--- a/ufmt/config.py
+++ b/ufmt/config.py
@@ -1,12 +1,14 @@
 # Copyright 2022 Amethyst Reese
 # Licensed under the MIT license
-
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import List, Optional, Sequence
 
 import tomlkit
 from trailrunner import project_root
+
+LOG = logging.getLogger(__name__)
 
 
 @dataclass
@@ -22,13 +24,26 @@ def ufmt_config(path: Optional[Path] = None) -> UfmtConfig:
     config_path = root / "pyproject.toml"
     if config_path.is_file():
         pyproject = tomlkit.loads(config_path.read_text())
-        config: Dict[str, Any] = {}
+        config = pyproject.get("tool", {}).get("ufmt", {})
+        if not isinstance(config, dict):
+            LOG.warning("%s: tool.ufmt is not a mapping, ignoring", config_path)
+            config = {}
 
-        if "tool" in pyproject and "ufmt" in pyproject["tool"]:  # type: ignore
-            config.update(pyproject["tool"]["ufmt"])  # type: ignore
+        config_excludes = config.pop("excludes", [])
+        if isinstance(config_excludes, Sequence) and not isinstance(
+            config_excludes, str
+        ):
+            excludes = [str(x) for x in config_excludes]
+        else:
+            raise ValueError(f"{config_path}: excludes must be a list of strings")
 
-        config["project_root"] = root
-        config["pyproject_path"] = config_path
-        return UfmtConfig(**config)
+        if config:
+            LOG.warning("%s: unknown values ignored: %r", config_path, sorted(config))
+
+        return UfmtConfig(
+            project_root=root,
+            pyproject_path=config_path,
+            excludes=excludes,
+        )
 
     return UfmtConfig()

--- a/ufmt/tests/config.py
+++ b/ufmt/tests/config.py
@@ -14,6 +14,13 @@ from ufmt.config import ufmt_config, UfmtConfig
 class ConfigTest(TestCase):
     maxDiff = None
 
+    def setUp(self):
+        self._td = TemporaryDirectory()
+        self.addCleanup(self._td.cleanup)
+
+        self.td = Path(self._td.name).resolve()
+        self.pyproject = self.td / "pyproject.toml"
+
     def test_ufmt_config(self):
         fake_config = dedent(
             """
@@ -22,61 +29,67 @@ class ConfigTest(TestCase):
                 "a",
                 "b",
             ]
-        """
+            """
         )
 
-        with TemporaryDirectory() as td:
-            td = Path(td).resolve()
-            foo = td / "foo"
-            foo.mkdir()
-            bar = foo / "bar.py"
-            bar.write_text("print('hello world')\n")
+        foo = self.td / "foo"
+        foo.mkdir()
+        bar = foo / "bar.py"
+        bar.write_text("print('hello world')\n")
 
-            with self.subTest("absolute path, no pyproject.toml"):
-                config = ufmt_config(bar)
+        with self.subTest("absolute path, no pyproject.toml"):
+            config = ufmt_config(bar)
+            self.assertEqual(UfmtConfig(), config)
+
+        with self.subTest("local path, no pyproject.toml"):
+            with cd(foo):
+                config = ufmt_config()
                 self.assertEqual(UfmtConfig(), config)
 
-            with self.subTest("local path, no pyproject.toml"):
-                with cd(foo):
-                    config = ufmt_config()
-                    self.assertEqual(UfmtConfig(), config)
+        self.pyproject.write_text("")
 
-            pyproj = td / "pyproject.toml"
-            pyproj.write_text("")
+        with self.subTest("absolute path, empty pyproject.toml"):
+            config = ufmt_config(bar)
+            self.assertEqual(
+                UfmtConfig(
+                    project_root=self.td, pyproject_path=self.pyproject, excludes=[]
+                ),
+                config,
+            )
 
-            with self.subTest("absolute path, empty pyproject.toml"):
-                config = ufmt_config(bar)
-                self.assertEqual(
-                    UfmtConfig(project_root=td, pyproject_path=pyproj, excludes=[]),
-                    config,
-                )
-
-            with self.subTest("local path, empty pyproject.toml"):
-                with cd(td):
-                    config = ufmt_config()
-                    self.assertEqual(
-                        UfmtConfig(project_root=td, pyproject_path=pyproj, excludes=[]),
-                        config,
-                    )
-
-            pyproj = td / "pyproject.toml"
-            pyproj.write_text(fake_config)
-
-            with self.subTest("absolute path, with pyproject.toml"):
-                config = ufmt_config(bar)
+        with self.subTest("local path, empty pyproject.toml"):
+            with cd(self.td):
+                config = ufmt_config()
                 self.assertEqual(
                     UfmtConfig(
-                        project_root=td, pyproject_path=pyproj, excludes=["a", "b"]
+                        project_root=self.td,
+                        pyproject_path=self.pyproject,
+                        excludes=[],
                     ),
                     config,
                 )
 
-            with self.subTest("local path, with pyproject.toml"):
-                with cd(td):
-                    config = ufmt_config()
-                    self.assertEqual(
-                        UfmtConfig(
-                            project_root=td, pyproject_path=pyproj, excludes=["a", "b"]
-                        ),
-                        config,
-                    )
+        self.pyproject.write_text(fake_config)
+
+        with self.subTest("absolute path, with pyproject.toml"):
+            config = ufmt_config(bar)
+            self.assertEqual(
+                UfmtConfig(
+                    project_root=self.td,
+                    pyproject_path=self.pyproject,
+                    excludes=["a", "b"],
+                ),
+                config,
+            )
+
+        with self.subTest("local path, with pyproject.toml"):
+            with cd(self.td):
+                config = ufmt_config()
+                self.assertEqual(
+                    UfmtConfig(
+                        project_root=self.td,
+                        pyproject_path=self.pyproject,
+                        excludes=["a", "b"],
+                    ),
+                    config,
+                )


### PR DESCRIPTION
This PR adds slightly stricter validation for the ufmt configuration read from `pyproject.toml`.

Previously, trying to `print(config.excludes)` within `ufmt` (while debugging #138) could result in

```
  File "tomlkit/items.py", line 1415, in <listcomp>
    return str([v.value.value for v in self._iter_items() if v.value is not None])
                ^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'value'
```
which was a bit strange, so I dug in and realized basically _any_ old stuff from `pyproject.toml` could end up in the `config` dict, and dataclasses don't do runtime validation...