### PR TITLE
Return exit code 0 if there are no files

### DIFF
--- a/ufmt/cli.py
+++ b/ufmt/cli.py
@@ -62,10 +62,6 @@ def echo_results(
         else:
             clean += 1
 
-    if empty:
-        click.secho("No files found", fg="yellow", err=True)
-        error += 1
-
     if not quiet:
 
         def f(v: int) -> str:
@@ -83,8 +79,11 @@ def echo_results(
         if clean:
             reports += [click.style(f"{clean} {f(clean)} already formatted")]
 
-        message = ", ".join(reports)
-        click.secho(f"✨ {message} ✨", err=True)
+        if empty:
+            click.secho("❗️ No files found ❗️", fg="yellow", err=True)
+        else:
+            message = ", ".join(reports)
+            click.secho(f"✨ {message} ✨", err=True)
 
     return (changed + written), error
 

--- a/ufmt/tests/cli.py
+++ b/ufmt/tests/cli.py
@@ -107,7 +107,7 @@ class CliTest(TestCase):
             result = self.runner.invoke(main, ["check"])
             ufmt_mock.assert_called_with([Path(".")], dry_run=True)
             self.assertRegex(result.stderr, r"No files found")
-            self.assertEqual(1, result.exit_code)
+            self.assertEqual(0, result.exit_code)
 
         with self.subTest("already formatted"):
             ufmt_mock.reset_mock()
@@ -174,7 +174,7 @@ class CliTest(TestCase):
             result = self.runner.invoke(main, ["diff"])
             ufmt_mock.assert_called_with([Path(".")], dry_run=True, diff=True)
             self.assertRegex(result.stderr, r"No files found")
-            self.assertEqual(1, result.exit_code)
+            self.assertEqual(0, result.exit_code)
 
         with self.subTest("already formatted"):
             ufmt_mock.reset_mock()
@@ -251,7 +251,7 @@ class CliTest(TestCase):
             result = self.runner.invoke(main, ["format"])
             ufmt_mock.assert_called_with([Path(".")])
             self.assertRegex(result.stderr, r"No files found")
-            self.assertEqual(1, result.exit_code)
+            self.assertEqual(0, result.exit_code)
 
         with self.subTest("already formatted"):
             ufmt_mock.reset_mock()


### PR DESCRIPTION
See https://github.com/omnilib/ufmt/issues/148 for more context, this PR changes the behavior so if no files are found we print a message but the command returns successfully.