### PR TITLE
Add `--root` flag to specify project configuration

### DIFF
--- a/ufmt/cli.py
+++ b/ufmt/cli.py
@@ -106,7 +106,7 @@ def echo_results(
 )
 @click.option(
     "--root",
-    type=str,
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
     default=None,
     help="Specify the root directory for project configuration",
 )
@@ -114,18 +114,15 @@ def main(
     ctx: click.Context,
     debug: Optional[bool],
     concurrency: Optional[int],
-    root: Optional[str],
+    root: Optional[Path],
 ):
     init_logging(debug=debug)
-    root_dir = Path(root) if root is not None else None
-    if root_dir is not None and not root_dir.is_dir():
-        raise ValueError("Root must be a valid directory")
 
     ctx.obj = Options(
         debug=debug is True,
         quiet=debug is False,
         concurrency=concurrency,
-        root=root_dir,
+        root=root,
     )
     enable_libcst_native()
 

--- a/ufmt/config.py
+++ b/ufmt/config.py
@@ -18,9 +18,10 @@ class UfmtConfig:
     excludes: List[str] = field(default_factory=list)
 
 
-def ufmt_config(path: Optional[Path] = None) -> UfmtConfig:
+def ufmt_config(path: Optional[Path] = None, root: Optional[Path] = None) -> UfmtConfig:
     path = path or Path.cwd()
-    root = project_root(path)
+    if root is None:
+        root = project_root(path)
     config_path = root / "pyproject.toml"
     if config_path.is_file():
         pyproject = tomlkit.loads(config_path.read_text())

--- a/ufmt/core.py
+++ b/ufmt/core.py
@@ -316,6 +316,7 @@ def ufmt_paths(
     pre_processor: Optional[Processor] = None,
     post_processor: Optional[Processor] = None,
     concurrency: Optional[int] = None,
+    root: Optional[Path] = None,
 ) -> Generator[Result, None, None]:
     """
     Format one or more paths, recursively, ignoring any files excluded by configuration.
@@ -375,7 +376,7 @@ def ufmt_paths(
         if path == STDIN:
             LOG.warning("Cannot mix stdin ('-') with normal paths, ignoring")
             continue
-        config = ufmt_config(path)
+        config = ufmt_config(path, root)
         all_paths.extend(runner.walk(path, excludes=config.excludes))
 
     if not all_paths:

--- a/ufmt/tests/cli.py
+++ b/ufmt/tests/cli.py
@@ -105,7 +105,9 @@ class CliTest(TestCase):
             ufmt_mock.reset_mock()
             ufmt_mock.return_value = []
             result = self.runner.invoke(main, ["check"])
-            ufmt_mock.assert_called_with([Path(".")], dry_run=True, concurrency=None)
+            ufmt_mock.assert_called_with(
+                [Path(".")], dry_run=True, concurrency=None, root=None
+            )
             self.assertRegex(result.stderr, r"No files found")
             self.assertEqual(0, result.exit_code)
 
@@ -117,7 +119,10 @@ class CliTest(TestCase):
             ]
             result = self.runner.invoke(main, ["check", "bar.py", "foo/frob.py"])
             ufmt_mock.assert_called_with(
-                [Path("bar.py"), Path("foo/frob.py")], dry_run=True, concurrency=None
+                [Path("bar.py"), Path("foo/frob.py")],
+                dry_run=True,
+                concurrency=None,
+                root=None,
             )
             self.assertEqual(0, result.exit_code)
 
@@ -129,7 +134,10 @@ class CliTest(TestCase):
             ]
             result = self.runner.invoke(main, ["check", "bar.py", "foo/frob.py"])
             ufmt_mock.assert_called_with(
-                [Path("bar.py"), Path("foo/frob.py")], dry_run=True, concurrency=None
+                [Path("bar.py"), Path("foo/frob.py")],
+                dry_run=True,
+                concurrency=None,
+                root=None,
             )
             self.assertEqual(1, result.exit_code)
 
@@ -149,7 +157,10 @@ class CliTest(TestCase):
             ]
             result = self.runner.invoke(main, ["check", "bar.py", "foo/frob.py"])
             ufmt_mock.assert_called_with(
-                [Path("bar.py"), Path("foo/frob.py")], dry_run=True, concurrency=None
+                [Path("bar.py"), Path("foo/frob.py")],
+                dry_run=True,
+                concurrency=None,
+                root=None,
             )
             self.assertRegex(
                 result.stderr, r"Error formatting .*frob\.py: Syntax Error @ 4:16"
@@ -163,7 +174,7 @@ class CliTest(TestCase):
             ]
             result = self.runner.invoke(main, ["check", "foo.py"])
             ufmt_mock.assert_called_with(
-                [Path("foo.py")], dry_run=True, concurrency=None
+                [Path("foo.py")], dry_run=True, concurrency=None, root=None
             )
             self.assertRegex(result.stderr, r"Skipped .*foo\.py: special")
             self.assertEqual(0, result.exit_code)
@@ -175,7 +186,7 @@ class CliTest(TestCase):
             ufmt_mock.return_value = []
             result = self.runner.invoke(main, ["diff"])
             ufmt_mock.assert_called_with(
-                [Path(".")], dry_run=True, diff=True, concurrency=None
+                [Path(".")], dry_run=True, diff=True, concurrency=None, root=None
             )
             self.assertRegex(result.stderr, r"No files found")
             self.assertEqual(0, result.exit_code)
@@ -192,6 +203,7 @@ class CliTest(TestCase):
                 dry_run=True,
                 diff=True,
                 concurrency=None,
+                root=None,
             )
             self.assertEqual(0, result.exit_code)
 
@@ -207,6 +219,7 @@ class CliTest(TestCase):
                 dry_run=True,
                 diff=True,
                 concurrency=None,
+                root=None,
             )
             self.assertEqual(1, result.exit_code)
 
@@ -230,6 +243,7 @@ class CliTest(TestCase):
                 dry_run=True,
                 diff=True,
                 concurrency=None,
+                root=None,
             )
             self.assertRegex(
                 result.stderr, r"Error formatting .*frob\.py: Syntax Error @ 4:16"
@@ -243,7 +257,7 @@ class CliTest(TestCase):
             ]
             result = self.runner.invoke(main, ["diff", "foo.py"])
             ufmt_mock.assert_called_with(
-                [Path("foo.py")], dry_run=True, diff=True, concurrency=None
+                [Path("foo.py")], dry_run=True, diff=True, concurrency=None, root=None
             )
             self.assertRegex(result.stderr, r"Skipped .*foo\.py: special")
             self.assertEqual(0, result.exit_code)
@@ -255,10 +269,24 @@ class CliTest(TestCase):
             ]
             result = self.runner.invoke(main, ["--quiet", "diff", "foo.py"])
             ufmt_mock.assert_called_with(
-                [Path("foo.py")], dry_run=True, diff=True, concurrency=None
+                [Path("foo.py")], dry_run=True, diff=True, concurrency=None, root=None
             )
             self.assertEqual("", result.stderr)
             self.assertEqual(0, result.exit_code)
+
+        with self.subTest("bad root dir"):
+            ufmt_mock.reset_mock()
+            ufmt_mock.return_value = [
+                Result(Path("bar.py"), changed=False),
+            ]
+            result = self.runner.invoke(
+                main, ["--root", "DOES_NOT_EXIST", "diff", "bar.py"]
+            )
+            self.assertRegex(
+                result.exception.args[0],
+                r"Root must be a valid directory",
+            )
+            self.assertEqual(1, result.exit_code)
 
     @patch("ufmt.cli.ufmt_paths")
     def test_format(self, ufmt_mock):
@@ -266,7 +294,7 @@ class CliTest(TestCase):
             ufmt_mock.reset_mock()
             ufmt_mock.return_value = []
             result = self.runner.invoke(main, ["format"])
-            ufmt_mock.assert_called_with([Path(".")], concurrency=None)
+            ufmt_mock.assert_called_with([Path(".")], concurrency=None, root=None)
             self.assertRegex(result.stderr, r"No files found")
             self.assertEqual(0, result.exit_code)
 
@@ -278,7 +306,7 @@ class CliTest(TestCase):
             ]
             result = self.runner.invoke(main, ["format", "bar.py", "foo/frob.py"])
             ufmt_mock.assert_called_with(
-                [Path("bar.py"), Path("foo/frob.py")], concurrency=None
+                [Path("bar.py"), Path("foo/frob.py")], concurrency=None, root=None
             )
             self.assertEqual(0, result.exit_code)
 
@@ -290,7 +318,7 @@ class CliTest(TestCase):
             ]
             result = self.runner.invoke(main, ["format", "bar.py", "foo/frob.py"])
             ufmt_mock.assert_called_with(
-                [Path("bar.py"), Path("foo/frob.py")], concurrency=None
+                [Path("bar.py"), Path("foo/frob.py")], concurrency=None, root=None
             )
             self.assertEqual(0, result.exit_code)
 
@@ -310,7 +338,7 @@ class CliTest(TestCase):
             ]
             result = self.runner.invoke(main, ["format", "bar.py", "foo/frob.py"])
             ufmt_mock.assert_called_with(
-                [Path("bar.py"), Path("foo/frob.py")], concurrency=None
+                [Path("bar.py"), Path("foo/frob.py")], concurrency=None, root=None
             )
             self.assertRegex(
                 result.stderr, r"Error formatting .*frob\.py: Syntax Error @ 4:16"
@@ -323,7 +351,7 @@ class CliTest(TestCase):
                 Result(Path("foo.py"), skipped="special"),
             ]
             result = self.runner.invoke(main, ["format", "foo.py"])
-            ufmt_mock.assert_called_with([Path("foo.py")], concurrency=None)
+            ufmt_mock.assert_called_with([Path("foo.py")], concurrency=None, root=None)
             self.assertRegex(result.stderr, r"Skipped .*foo\.py: special")
             self.assertEqual(0, result.exit_code)
 

--- a/ufmt/tests/cli.py
+++ b/ufmt/tests/cli.py
@@ -282,11 +282,11 @@ class CliTest(TestCase):
             result = self.runner.invoke(
                 main, ["--root", "DOES_NOT_EXIST", "diff", "bar.py"]
             )
-            self.assertRegex(
-                result.exception.args[0],
-                r"Root must be a valid directory",
+            self.assertIn(
+                r"Directory 'DOES_NOT_EXIST' does not exist",
+                result.stderr,
             )
-            self.assertEqual(1, result.exit_code)
+            self.assertEqual(2, result.exit_code)
 
     @patch("ufmt.cli.ufmt_paths")
     def test_format(self, ufmt_mock):

--- a/ufmt/tests/config.py
+++ b/ufmt/tests/config.py
@@ -95,6 +95,17 @@ class ConfigTest(TestCase):
                     config,
                 )
 
+        with self.subTest("absolute path, manually specify project root"):
+            config = ufmt_config(root=self.td)
+            self.assertEqual(
+                UfmtConfig(
+                    project_root=self.td,
+                    pyproject_path=self.pyproject,
+                    excludes=["a", "b"],
+                ),
+                config,
+            )
+
     @patch("ufmt.config.LOG")
     def test_invalid_config(self, log_mock):
         with self.subTest("string"):

--- a/ufmt/types.py
+++ b/ufmt/types.py
@@ -24,6 +24,7 @@ class Options:
     debug: bool = False
     quiet: bool = False
     concurrency: Optional[int] = None
+    root: Optional[Path] = None
 
 
 class Processor(Protocol):


### PR DESCRIPTION
For https://github.com/omnilib/ufmt/issues/110 there are use cases where projects might have multiple pyproject.toml files in the repo for various configurations but we want to store all the `ufmt`/`usort`/`black` configuration in one place. Currently there is no easy way to do this without calling `ufmt` directly on the root of the project which can be super expensive in large projects.

This adds a new flag so you can specify the root. This works well for the general configuration but I want to point out one area where it does not work correctly, specifically with excludes.

Say you have this set up
```
$ ls **
pyproject.toml

a:
a.py            pyproject.toml

b:
b.py

$ cat pyproject.toml
[tool.ufmt]
excludes = [
    "/a/",
]
```
all other files are empty. Then if you format the root you would expect only `b` to be formatted. If you format the `a` directory then `a.py` will get formatted currently as well.
```
$ ufmt --debug check .
DEBUG ufmt.core Checking /private/tmp/project/b/b.py
✨ 1 file already formatted ✨
$ ufmt --debug check a
DEBUG ufmt.core Checking /private/tmp/project/a/a.py
✨ 1 file already formatted ✨
```
works as expected. the issue is now with the new flag in this PR, specifying the root and formatting directory `a` doesn't do what we expect
```
$ ufmt --root=. --debug check a
DEBUG ufmt.core Checking /private/tmp/project/a/a.py
✨ 1 file already formatted ✨
```
The issue is that overriding the `root` here is insufficient, we would also need to tell `Trailrunner` about it too, see https://github.com/omnilib/trailrunner/blob/main/trailrunner/core.py#L170

So this flag will help with some configuration but it might be confusing in terms of the excludes unless we also patch the other library to allow you to set the root.