### PR TITLE
Support alternate sorters, or skipping sorting step

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -13,7 +13,7 @@ following this example:
 .. code-block:: toml
 
     [tool.ufmt]
-    excludes = [...]
+    excludes = []
 
 Options available are described as follows:
 

--- a/ufmt/config.py
+++ b/ufmt/config.py
@@ -1,29 +1,20 @@
 # Copyright 2022 Amethyst Reese
 # Licensed under the MIT license
 import logging
-from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
-from typing import List, Optional, Sequence
+from typing import Optional, Sequence
 
 import tomlkit
 from trailrunner import project_root
 
-from .types import Formatter
+from .types import Formatter, UfmtConfig
 
 LOG = logging.getLogger(__name__)
 
 
-@dataclass
-class UfmtConfig:
-    project_root: Optional[Path] = None
-    pyproject_path: Optional[Path] = None
-    excludes: List[str] = field(default_factory=list)
-    formatter: Formatter = Formatter.black
-
-
 @lru_cache
-def ufmt_config(path: Optional[Path] = None, root: Optional[Path] = None) -> UfmtConfig:
+def load_config(path: Optional[Path] = None, root: Optional[Path] = None) -> UfmtConfig:
     path = path or Path.cwd()
     if root is None:
         root = project_root(path)

--- a/ufmt/tests/config.py
+++ b/ufmt/tests/config.py
@@ -9,7 +9,7 @@ from unittest.mock import ANY, patch
 
 from trailrunner.tests.core import cd
 
-from ufmt.config import ufmt_config, UfmtConfig
+from ufmt.config import load_config, UfmtConfig
 
 
 class ConfigTest(TestCase):
@@ -23,7 +23,7 @@ class ConfigTest(TestCase):
         self.pyproject = self.td / "pyproject.toml"
 
     def subTest(self, *args, **kwargs):
-        ufmt_config.cache_clear()
+        load_config.cache_clear()
         return super().subTest(*args, **kwargs)
 
     def test_ufmt_config(self):
@@ -43,18 +43,18 @@ class ConfigTest(TestCase):
         bar.write_text("print('hello world')\n")
 
         with self.subTest("absolute path, no pyproject.toml"):
-            config = ufmt_config(bar)
+            config = load_config(bar)
             self.assertEqual(UfmtConfig(), config)
 
         with self.subTest("local path, no pyproject.toml"):
             with cd(foo):
-                config = ufmt_config()
+                config = load_config()
                 self.assertEqual(UfmtConfig(), config)
 
         self.pyproject.write_text("")
 
         with self.subTest("absolute path, empty pyproject.toml"):
-            config = ufmt_config(bar)
+            config = load_config(bar)
             self.assertEqual(
                 UfmtConfig(
                     project_root=self.td, pyproject_path=self.pyproject, excludes=[]
@@ -64,7 +64,7 @@ class ConfigTest(TestCase):
 
         with self.subTest("local path, empty pyproject.toml"):
             with cd(self.td):
-                config = ufmt_config()
+                config = load_config()
                 self.assertEqual(
                     UfmtConfig(
                         project_root=self.td,
@@ -77,7 +77,7 @@ class ConfigTest(TestCase):
         self.pyproject.write_text(fake_config)
 
         with self.subTest("absolute path, with pyproject.toml"):
-            config = ufmt_config(bar)
+            config = load_config(bar)
             self.assertEqual(
                 UfmtConfig(
                     project_root=self.td,
@@ -89,7 +89,7 @@ class ConfigTest(TestCase):
 
         with self.subTest("local path, with pyproject.toml"):
             with cd(self.td):
-                config = ufmt_config()
+                config = load_config()
                 self.assertEqual(
                     UfmtConfig(
                         project_root=self.td,
@@ -100,7 +100,7 @@ class ConfigTest(TestCase):
                 )
 
         with self.subTest("absolute path, manually specify project root"):
-            config = ufmt_config(root=self.td)
+            config = load_config(root=self.td)
             self.assertEqual(
                 UfmtConfig(
                     project_root=self.td,
@@ -122,7 +122,7 @@ class ConfigTest(TestCase):
                 )
             )
             expected = UfmtConfig(project_root=self.td, pyproject_path=self.pyproject)
-            result = ufmt_config(self.td / "fake.py")
+            result = load_config(self.td / "fake.py")
             self.assertEqual(expected, result)
 
             log_mock.warning.assert_called_once()
@@ -138,7 +138,7 @@ class ConfigTest(TestCase):
                 )
             )
             expected = UfmtConfig(project_root=self.td, pyproject_path=self.pyproject)
-            result = ufmt_config(self.td / "fake.py")
+            result = load_config(self.td / "fake.py")
             self.assertEqual(expected, result)
 
             log_mock.warning.assert_called_once()
@@ -155,7 +155,7 @@ class ConfigTest(TestCase):
                 )
             )
             expected = UfmtConfig(project_root=self.td, pyproject_path=self.pyproject)
-            result = ufmt_config(self.td / "fake.py")
+            result = load_config(self.td / "fake.py")
             self.assertEqual(expected, result)
 
             log_mock.warning.assert_called_with(
@@ -175,7 +175,7 @@ class ConfigTest(TestCase):
             with self.assertRaisesRegex(
                 ValueError, "'garbage' is not a valid Formatter"
             ):
-                ufmt_config(self.td / "fake.py")
+                load_config(self.td / "fake.py")
 
     @patch("ufmt.config.LOG")
     def test_config_excludes(self, log_mock):
@@ -188,7 +188,7 @@ class ConfigTest(TestCase):
                 )
             )
             expected = UfmtConfig(project_root=self.td, pyproject_path=self.pyproject)
-            result = ufmt_config(self.td / "fake.py")
+            result = load_config(self.td / "fake.py")
             self.assertEqual(expected, result)
             log_mock.assert_not_called()
 
@@ -204,7 +204,7 @@ class ConfigTest(TestCase):
             expected = UfmtConfig(
                 project_root=self.td, pyproject_path=self.pyproject, excludes=[]
             )
-            result = ufmt_config(self.td / "fake.py")
+            result = load_config(self.td / "fake.py")
             self.assertEqual(expected, result)
             log_mock.assert_not_called()
 
@@ -222,7 +222,7 @@ class ConfigTest(TestCase):
                 pyproject_path=self.pyproject,
                 excludes=["fixtures/"],
             )
-            result = ufmt_config(self.td / "fake.py")
+            result = load_config(self.td / "fake.py")
             self.assertEqual(expected, result)
             log_mock.assert_not_called()
 
@@ -238,4 +238,4 @@ class ConfigTest(TestCase):
             with self.assertRaisesRegex(
                 ValueError, "excludes must be a list of strings"
             ):
-                ufmt_config(self.td / "fake.py")
+                load_config(self.td / "fake.py")

--- a/ufmt/types.py
+++ b/ufmt/types.py
@@ -1,10 +1,10 @@
 # Copyright 2022 Amethyst Reese, Tim Hatch
 # Licensed under the MIT license
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Callable, Optional, Union
+from typing import Callable, List, Optional, Union
 
 from black import Mode as BlackConfig
 from typing_extensions import Protocol
@@ -38,6 +38,30 @@ class Formatter(Enum):
         table from ``pyproject.toml`` rather than Ruff's own configuration options.
         This may change in future updates.
     """
+
+
+class Sorter(Enum):
+    """
+    Preferred import sorter implementation.
+    """
+
+    skip = "skip"
+    """Skip sorting imports"""
+
+    usort = "usort"
+    """Use µsort (default)."""
+
+
+@dataclass
+class UfmtConfig:
+    project_root: Optional[Path] = None
+    pyproject_path: Optional[Path] = None
+    excludes: List[str] = field(default_factory=list)
+    formatter: Formatter = Formatter.black
+    sorter: Sorter = Sorter.usort
+
+
+UfmtConfigFactory = Callable[[Optional[Path], Optional[Path]], UfmtConfig]
 
 
 @dataclass


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #195
* #194
* #193
* __->__ #192
* #191

- Move UfmtConfig to types module
- Rename ufmt_config() to load_config()
- Replace `formatter` option in ufmt_bytes with ufmt config
- Pass ufmt config factory through and create configs from factories
- Docs update