### PR TITLE
Pass target file path to ufmt config factory

### DIFF
--- a/ufmt/core.py
+++ b/ufmt/core.py
@@ -234,7 +234,7 @@ def ufmt_file(
     the skip exception, or ``True`` if no message is given.
     """
     path = path.resolve()
-    ufmt_config = (ufmt_config_factory or load_config)(path.parent, root)
+    ufmt_config = (ufmt_config_factory or load_config)(path, root)
     black_config = (black_config_factory or make_black_config)(path)
     usort_config = (usort_config_factory or UsortConfig.find)(path)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #197

This fixes `ufmt_file` to pass the full file path to the ufmt config
factory, rather than just the path's parent. This enables alternate
config factories to make decisions based on the target filename, suffix,
etc that can't be made just based on the parent path. This also aligns
with config factory usage for black and usort.

Fixes #196