### PR TITLE
Pass project root to ruff-api

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ lsp = [
     "pygls >= 1.3",
 ]
 ruff = [
-    "ruff-api>=0.0.5",
+    "ruff-api>=0.0.8",
 ]
 dev = [
     "attribution==1.8.0",

--- a/ufmt/core.py
+++ b/ufmt/core.py
@@ -122,7 +122,14 @@ def ufmt_bytes(
             ],
         )
         content_str = ruff_api.isort_string(
-            path.as_posix(), content.decode(encoding), options=ruff_isort_options
+            path.as_posix(),
+            content.decode(encoding),
+            options=ruff_isort_options,
+            root=(
+                ufmt_config.project_root.as_posix()
+                if ufmt_config.project_root
+                else None
+            ),
         )
         content = content_str.encode(encoding)
     elif ufmt_config.sorter == Sorter.skip:

--- a/ufmt/tests/core.py
+++ b/ufmt/tests/core.py
@@ -7,7 +7,7 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
-from unittest.mock import call, Mock, patch
+from unittest.mock import ANY, call, Mock, patch
 
 import black
 import ruff_api
@@ -250,7 +250,10 @@ class CoreTest(TestCase):
                 usort_config=usort_config,
             )
             self.assertEqual(CORRECTLY_FORMATTED_CODE.encode(), result)
-            usort_mock.assert_called_once()
+            usort_mock.assert_called_with(
+                POORLY_FORMATTED_CODE.encode(), usort_config, Path("foo.py")
+            )
+            ruff_mock.assert_not_called()
 
         with self.subTest("ruff-api"):
             usort_mock.reset_mock()
@@ -263,7 +266,9 @@ class CoreTest(TestCase):
             )
             self.assertEqual(CORRECTLY_FORMATTED_CODE.encode(), result)
             usort_mock.assert_not_called()
-            ruff_mock.assert_called_once()
+            ruff_mock.assert_called_with(
+                "foo.py", POORLY_FORMATTED_CODE, options=ANY, root=None
+            )
 
         with self.subTest("skip"):
             usort_mock.reset_mock()


### PR DESCRIPTION
This helps ensure that ruff can correctly discover first party
imports when sorting in memory. If none, it falls back to CWD.
