### PR TITLE
Start passing extra sorting options to ruff-api

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ lsp = [
     "pygls >= 1.3",
 ]
 ruff = [
-    "ruff-api>=0.0.8",
+    "ruff-api>=0.1.0",
 ]
 dev = [
     "attribution==1.8.0",
@@ -44,7 +44,7 @@ dev = [
     "flake8==7.1.1",
     "mypy==1.11.2",
     "pygls==1.3.1",
-    "ruff-api==0.0.8",
+    "ruff-api==0.1.0",
     "usort==1.0.8.post1",
 ]
 docs = [

--- a/ufmt/core.py
+++ b/ufmt/core.py
@@ -110,6 +110,7 @@ def ufmt_bytes(
         content = result.output
     elif ufmt_config.sorter == Sorter.ruff_api:
         ruff_isort_options = ruff_api.SortOptions(
+            # match µsort configuration
             first_party_modules=[
                 imp
                 for imp, category in usort_config.known.items()
@@ -120,6 +121,11 @@ def ufmt_bytes(
                 for imp, category in usort_config.known.items()
                 if category == CAT_STANDARD_LIBRARY
             ],
+            detect_same_package=usort_config.first_party_detection,
+            # match µsort behavior for now
+            case_sensitive=False,
+            combine_as_imports=True,
+            order_by_type=False,
         )
         content_str = ruff_api.isort_string(
             path.as_posix(),


### PR DESCRIPTION
Depends on ruff-api v0.1.0. Fixes #246
