### PR TITLE
make tests compatible with click 8.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev = [
     "pygls==1.3.1",
     "ruff-api==0.1.0",
     "usort==1.0.8.post1",
+    "packaging",
 ]
 docs = [
     "sphinx==8.1.3",

--- a/ufmt/tests/cli.py
+++ b/ufmt/tests/cli.py
@@ -4,6 +4,7 @@
 import os
 import platform
 from concurrent.futures import ThreadPoolExecutor
+from importlib.metadata import version
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import skipIf, TestCase
@@ -12,6 +13,7 @@ from unittest.mock import call, Mock, patch
 import trailrunner
 from click.testing import CliRunner
 from libcst import ParserSyntaxError
+from packaging.version import Version
 
 from ufmt.cli import echo_results, main
 from ufmt.types import Result
@@ -22,7 +24,10 @@ from .core import CORRECTLY_FORMATTED_CODE, POORLY_FORMATTED_CODE
 @patch.object(trailrunner.core.Trailrunner, "DEFAULT_EXECUTOR", ThreadPoolExecutor)
 class CliTest(TestCase):
     def setUp(self) -> None:
-        self.runner = CliRunner(mix_stderr=False)
+        if Version(version("click")) >= Version("8.2.0"):
+            self.runner = CliRunner()
+        else:
+            self.runner = CliRunner(mix_stderr=False)
         self.cwd = os.getcwd()
         self.td = TemporaryDirectory()
         self.tdp = Path(self.td.name).resolve()


### PR DESCRIPTION
mix_stderr has been removed from click 8.2.0:

https://click.palletsprojects.com/en/stable/changes/#version-8-2-0

> Keep stdout and stderr streams independent in CliRunner. Always
  collect stderr output and never raise an exception. Add a new output
  stream to simulate what the user sees in its terminal. Removes the
  mix_stderr parameter in CliRunner. #2522 #2523

Fixes: https://github.com/omnilib/ufmt/issues/259