### PR TITLE
Change crlf detection to look at first line 🙋‍♂️

### DIFF
--- a/ufmt/tests/util.py
+++ b/ufmt/tests/util.py
@@ -111,3 +111,13 @@ class UtilTest(TestCase):
                 result = ufmt.util.read_file(foo)
                 expected = (b"", "utf-8", b"\n")
                 self.assertTupleEqual(expected, result)
+
+    def test_line_endings(self) -> None:
+        # no op
+        self.assertEqual((b"a\nb\n", b"\n"), ufmt.util.normalize_content(b"a\nb\n"))
+        # dos newline
+        self.assertEqual(
+            (b"a\nb\n", b"\r\n"), ufmt.util.normalize_content(b"a\r\nb\r\n")
+        )
+        # mixed, leave alone if not first
+        self.assertEqual((b"a\nb\r\n", b"\n"), ufmt.util.normalize_content(b"a\nb\r\n"))

--- a/ufmt/util.py
+++ b/ufmt/util.py
@@ -1,6 +1,7 @@
 # Copyright 2022 Amethyst Reese, Tim Hatch
 # Licensed under the MIT license
 
+import io
 import os
 import tokenize
 from pathlib import Path
@@ -43,7 +44,8 @@ def normalize_content(
     No-op if ``newline`` is detected or given as ``b"\\n"``.
     """
     if newline is None:
-        newline = b"\r\n" if content.find(b"\r\n", 0, 1000) > -1 else b"\n"
+        lines = tokenize.detect_encoding(io.BytesIO(content).readline)[1]
+        newline = b"\r\n" if lines and lines[0].endswith(b"\r\n") else b"\n"
     if newline != b"\n":
         content = content.replace(newline, b"\n")
     return content, newline


### PR DESCRIPTION
The system used by tokenize is the de facto standard for what we think the
newline is