### PR TITLE
When formatting stdin, look for config in the proper dir 🙋‍♂️

### DIFF
--- a/ufmt/core.py
+++ b/ufmt/core.py
@@ -425,7 +425,8 @@ def ufmt_paths(
     from STDIN using :func:`ufmt_stdin`. Results will be printed to STDOUT.
     A second path argument may be given, which represents the original content's true
     path name, and will be used when printing status messages, diffs, or errors.
-    Any further path names will result in a runtime error.
+    Any further path names will result in a runtime error.  If a path is not
+    explicitly provided, it falls back to the --root and then to the working dir.
 
     See :func:`ufmt_file` for details on parameters, config factories,
     and post processors. All parameters are passed through to :func:`ufmt_file`.
@@ -443,6 +444,8 @@ def ufmt_paths(
             raise ValueError("too many stdin paths")
         elif len(paths) == 2:
             _, path = paths
+        elif root:
+            path = root / Path("stdin")
         else:
             path = Path("stdin")
         yield ufmt_stdin(

--- a/ufmt/core.py
+++ b/ufmt/core.py
@@ -426,7 +426,7 @@ def ufmt_paths(
     A second path argument may be given, which represents the original content's true
     path name, and will be used when printing status messages, diffs, or errors.
     Any further path names will result in a runtime error.  If a path is not
-    explicitly provided, it falls back to the --root and then to the working dir.
+    explicitly provided, it falls back to ``--root`` and then to the working dir.
 
     See :func:`ufmt_file` for details on parameters, config factories,
     and post processors. All parameters are passed through to :func:`ufmt_file`.

--- a/ufmt/tests/core.py
+++ b/ufmt/tests/core.py
@@ -743,6 +743,57 @@ class CoreTest(TestCase):
                 post_processor=None,
             )
 
+        with self.subTest("root with abs path name"):
+            list(
+                ufmt.ufmt_paths(
+                    [STDIN, Path("/bar/hello.py")], dry_run=True, root=Path("/foo")
+                )
+            )
+            stdin_mock.assert_called_with(
+                Path("/bar/hello.py"),
+                dry_run=True,
+                diff=False,
+                return_content=False,
+                ufmt_config_factory=None,
+                black_config_factory=None,
+                usort_config_factory=None,
+                pre_processor=None,
+                post_processor=None,
+            )
+
+        with self.subTest("root with rel path name"):
+            list(
+                ufmt.ufmt_paths(
+                    [STDIN, Path("hello.py")], dry_run=True, root=Path("/foo")
+                )
+            )
+            # TODO: not sure I'm happy with this
+            stdin_mock.assert_called_with(
+                Path("hello.py"),
+                dry_run=True,
+                diff=False,
+                return_content=False,
+                ufmt_config_factory=None,
+                black_config_factory=None,
+                usort_config_factory=None,
+                pre_processor=None,
+                post_processor=None,
+            )
+
+        with self.subTest("root no path name"):
+            list(ufmt.ufmt_paths([STDIN], dry_run=True, root=Path("/foo")))
+            stdin_mock.assert_called_with(
+                Path("/foo/stdin"),
+                dry_run=True,
+                diff=False,
+                return_content=False,
+                ufmt_config_factory=None,
+                black_config_factory=None,
+                usort_config_factory=None,
+                pre_processor=None,
+                post_processor=None,
+            )
+
         with self.subTest("extra args"):
             with self.assertRaisesRegex(ValueError, "too many stdin paths"):
                 list(


### PR DESCRIPTION
Rewritten artisnally with more tests, this should cause `ufmt_stdin` to obey
`--root` instead of always falling back to the cwd when paths are not provided.
